### PR TITLE
:+1: google test 追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,69 @@
+NAME      := webserv
+
+CXX       := clang++
+CXXFLAGS  := -Wall -Wextra -Werror -std=c++98
+
+INCDIR    :=    ./include
+OBJDIR    :=    ./objs
+DPSDIR    :=    ./dps
+
+INCLUDE   := -I$(INCDIR)
+VPATH     := src:
+
+SRCS      := src/main.cpp
+
+OBJS      := $(addprefix $(OBJDIR)/, $(notdir $(SRCS:.cpp=.o)))
+DPS       := $(addprefix $(DPSDIR)/, $(notdir $(SRCS:.o=.d)))
+
+RM        := rm -rf
+
+all: makedir $(NAME)
+
+$(NAME): $(OBJS)
+	$(CXX) $(CXXFLAGS) -o $(NAME) $(OBJS) $(LIBS)
+
+$(OBJDIR)/%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -MMD -MP -MF $(DPSDIR)/$(notdir $(<:.cpp=.d)) -c $< -o $@
+
+-include $(DPS)
+
+makedir :
+	mkdir -p $(OBJDIR)
+	mkdir -p $(DPSDIR)
+
+clean:
+	rm -rf $(OBJDIR) $(DPSDIR)
+
+fclean: clean
+	$(RM) $(NAME) *.dSYM tester
+
+re: fclean all
+
+################# google test ####################
+
+gtestdir =    ./google_test
+gtest    =    $(gtestdir)/gtest $(gtestdir)/googletest-release-1.11.0
+testdir  = ./test
+
+$(gtest):
+	mkdir -p $(dir ../google_test)
+	curl -OL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.tar.gz
+	tar -xvzf release-1.11.0.tar.gz googletest-release-1.11.0
+	$(RM) -rf release-1.11.0.tar.gz
+	python googletest-release-1.11.0/googletest/scripts/fuse_gtest_files.py $(gtestdir)
+	mv googletest-release-1.11.0 $(gtestdir)
+
+test_compile = clang++ -std=c++11 \
+	$(testdir)/gtest.cpp $(gtestdir)/googletest-release-1.11.0/googletest/src/gtest_main.cc $(gtestdir)/gtest/gtest-all.cc \
+	-g -fsanitize=address -fsanitize=undefined -fsanitize=leak \
+	-I$(gtestdir) $(INCLUDE) -lpthread -o tester
+
+.PHONY: gtest
+gtest: $(gtest)
+	$(test_compile)
+	./tester
+# ./tester # --gtest_filter=Vector.other
+
+.PHONY: cleangtest
+cleangtest:
+	$(RM) $(gtestdir)

--- a/include/hoge.hpp
+++ b/include/hoge.hpp
@@ -1,0 +1,19 @@
+#ifndef HOGE_HPP
+#define HOGE_HPP
+
+class hoge
+{
+private:
+	int num_;
+public:
+	hoge(int i) : num_(i) {}
+	~hoge(){}
+
+	int get_num()
+	{
+		return num_;
+	}
+};
+
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,1 +1,7 @@
+#include <iostream>
 
+int main()
+{
+	std::cout << "HELLO WEBSERV" << std::endl;
+	return 0;
+}

--- a/test/gtest.cpp
+++ b/test/gtest.cpp
@@ -1,0 +1,10 @@
+
+#include <gtest/gtest.h>
+
+#define SIZE 1000
+#define cout std::cout
+#define endl std::endl
+
+/* Include all tests files */
+
+#include "test.cpp"

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+
+#include <hoge.hpp>
+
+TEST(Hoge, GetNum)
+{
+	{
+		hoge h(42);
+
+		EXPECT_EQ(42, h.get_num());
+	}
+}


### PR DESCRIPTION


## やったこと

- c++11でコンパイル可能な google test && Makefile を追加


## 動作確認

```bash
$ make gtest  # google test 起動
./tester
Running main() from ./google_test/googletest-release-1.11.0/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from Hoge
[ RUN      ] Hoge.GetNum
[       OK ] Hoge.GetNum (0 ms)
[----------] 1 test from Hoge (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.
```
```bash
$ make cleangtest # google_test 削除
```

## その他

- Makefile も追加しました。

## issues

about : #3 

close #3 
