### PR TITLE
:+1: Makefileにtidyとtidy-fixのコマンド追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ DPS       := $(addprefix $(DPSDIR)/, $(notdir $(SRCS:.o=.d)))
 
 RM        := rm -rf
 
+.PHONY: all
 all: makedir $(NAME)
 
 $(NAME): $(OBJS)
@@ -35,17 +36,29 @@ $(OBJDIR)/%.o: %.cpp
 
 -include $(DPS)
 
+.PHONY: makedir
 makedir :
 	mkdir -p $(OBJDIR)
 	mkdir -p $(DPSDIR)
 
+.PHONY: clean
 clean:
 	rm -rf $(OBJDIR) $(DPSDIR)
 
+.PHONY: fclean
 fclean: clean
 	$(RM) $(NAME) *.dSYM tester
 
+.PHONY: re
 re: fclean all
+
+.PHONY: tidy
+tidy:
+	clang-tidy `find src include -type f` -- -I$(INCDIR)
+
+.PHONY: tidy-fix
+tidy-fix:
+	clang-tidy `find src include -type f` --fix -- -I$(INCDIR)
 
 ################# google test ####################
 


### PR DESCRIPTION
## やったこと

- Makefileにtidyとtidy-fixのコマンド追加
- `make tidy-fix`で自動修正してくれるはず

## やらないこと

- pre-commitで`make tidy`を走らせてエラーが出たらコミットできないようにしてもいいかも？
- コンフリクトしそうなので実際のソースファイルの修正は行ってないです。

## 動作確認

```
❯ make tidy-fix
clang-tidy `find src include -type f` --fix -- -I./include
1 warning generated.
2 warnings generated.
7 warnings generated.
8 warnings generated.
8 warnings generated.
10 warnings generated.
15 warnings generated.
19 warnings generated.
20 warnings generated.
24 warnings generated.
25 warnings generated.
25 warnings generated.
27 warnings generated.
28 warnings generated.
33 warnings generated.
34 warnings generated.
35 warnings generated.
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/./include/ServerSocket.hpp:15:33: error: invalid case style for variable 'MAX_QUE' [readability-identifier-naming,-warnings-as-errors]
    static const unsigned short MAX_QUE = 1024;
                                ^~~~~~~
                                max_que
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/./include/ServerSocket.hpp:15:33: note: FIX-IT applied suggested code changes
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/./include/Socket.hpp:7:9: error: invalid case style for member 'sock_' [readability-identifier-naming,-warnings-as-errors]
    int sock_;
        ^~~~~
        sock
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/src/ClientSocket.cpp:10:5: note: FIX-IT applied suggested code changes
    sock_ = accept(server_sock, NULL, NULL);
    ^
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/src/ClientSocket.cpp:11:9: note: FIX-IT applied suggested code changes
    if (sock_ == -1)
        ^
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/./include/Socket.hpp:7:9: note: FIX-IT applied suggested code changes
    int sock_;
        ^
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/./include/SocketAddress.hpp:13:33: error: invalid case style for variable 'SERVER_PORT' [readability-identifier-naming,-warnings-as-errors]
    static const unsigned short SERVER_PORT = 4242;
                                ^~~~~~~~~~~
                                server_port
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/./include/SocketAddress.hpp:13:33: note: FIX-IT applied suggested code changes
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/./include/SocketAddress.hpp:14:33: error: invalid case style for variable 'SERVER_ADDR' [readability-identifier-naming,-warnings-as-errors]
    static const std::string    SERVER_ADDR;
                                ^~~~~~~~~~~
                                server_addr
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/./include/SocketAddress.hpp:14:33: note: FIX-IT applied suggested code changes
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/./include/WebServ.hpp:17:10: error: invalid case style for private method '_serverSocketRun' [readability-identifier-naming,-warnings-as-errors]
    void _serverSocketRun();
         ^~~~~~~~~~~~~~~~
         serverSocketRun_
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/./include/WebServ.hpp:17:10: note: FIX-IT applied suggested code changes
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/src/WebServ.cpp:19:5: note: FIX-IT applied suggested code changes
    _serverSocketRun();
    ^
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/src/WebServ.cpp:79:15: note: FIX-IT applied suggested code changes
void WebServ::_serverSocketRun()
              ^
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/include/ServerSocket.hpp:15:33: error: invalid case style for variable 'MAX_QUE' [readability-identifier-naming,-warnings-as-errors]
    static const unsigned short MAX_QUE = 1024;
                                ^~~~~~~
                                max_que
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/include/ServerSocket.hpp:15:33: note: FIX-IT applied suggested code changes
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/include/Socket.hpp:7:9: error: invalid case style for member 'sock_' [readability-identifier-naming,-warnings-as-errors]
    int sock_;
        ^~~~~
        sock
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/include/Socket.hpp:7:9: note: FIX-IT applied suggested code changes
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/include/SocketAddress.hpp:13:33: error: invalid case style for variable 'SERVER_PORT' [readability-identifier-naming,-warnings-as-errors]
    static const unsigned short SERVER_PORT = 4242;
                                ^~~~~~~~~~~
                                server_port
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/include/SocketAddress.hpp:13:33: note: FIX-IT applied suggested code changes
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/include/SocketAddress.hpp:14:33: error: invalid case style for variable 'SERVER_ADDR' [readability-identifier-naming,-warnings-as-errors]
    static const std::string    SERVER_ADDR;
                                ^~~~~~~~~~~
                                server_addr
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/include/SocketAddress.hpp:14:33: note: FIX-IT applied suggested code changes
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/include/WebServ.hpp:17:10: error: invalid case style for private method '_serverSocketRun' [readability-identifier-naming,-warnings-as-errors]
    void _serverSocketRun();
         ^~~~~~~~~~~~~~~~
         serverSocketRun_
/Users/sudourio/Desktop/42tokyo/rank05/webserv/webserv/include/WebServ.hpp:17:10: note: FIX-IT applied suggested code changes
clang-tidy applied 14 of 14 suggested fixes.
10 warnings treated as errors
make: *** [tidy-fix] Error 1

```

## issues

close #19 
