### PR TITLE
clang-format を修正

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,16 +32,16 @@ BinPackParameters: true
 BraceWrapping:
   AfterCaseLabel:  false
   AfterClass:      true
-  AfterControlStatement: Always
+  AfterControlStatement: Never
   AfterEnum:       false
-  AfterFunction:   true
+  AfterFunction:   false
   AfterNamespace:  false
   AfterObjCDeclaration: false
   AfterStruct:     false
   AfterUnion:      false
   AfterExternBlock: false
   BeforeCatch:     false
-  BeforeElse:      true
+  BeforeElse:      false
   BeforeLambdaBody: false
   BeforeWhile:     false
   IndentBraces:    false

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="ja">
 	<head>
 		<meta charset="UTF-8">
+		<link rel="icon" href="data:image/x-icon;," type="image/x-icon">
 		<title>INDEX.HTML</title>
 	</head>
 	<body>

--- a/src/ClientSocket.cpp
+++ b/src/ClientSocket.cpp
@@ -5,9 +5,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-ClientSocket::ClientSocket(int server_sock)
-{
-  (void)server_sock;
+ClientSocket::ClientSocket(int server_sock) {
+    (void)server_sock;
     // sock_ = accept(server_sock, NULL, NULL);
     // if (sock_ == -1)
     // {
@@ -16,4 +15,4 @@ ClientSocket::ClientSocket(int server_sock)
     // }
 }
 
-ClientSocket::~ClientSocket() { close(sock_);}
+ClientSocket::~ClientSocket() { close(sock_); }

--- a/src/ClientSocket.cpp
+++ b/src/ClientSocket.cpp
@@ -7,12 +7,13 @@
 
 ClientSocket::ClientSocket(int server_sock)
 {
-    sock_ = accept(server_sock, NULL, NULL);
-    if (sock_ == -1)
-    {
-        std::cout << "accept error" << std::endl;
-        throw std::runtime_error("accept error");
-    }
+  (void)server_sock;
+    // sock_ = accept(server_sock, NULL, NULL);
+    // if (sock_ == -1)
+    // {
+    //     std::cout << "accept error" << std::endl;
+    //     throw std::runtime_error("accept error");
+    // }
 }
 
-ClientSocket::~ClientSocket() {}
+ClientSocket::~ClientSocket() { close(sock_);}

--- a/src/HTTPParser.cpp
+++ b/src/HTTPParser.cpp
@@ -6,8 +6,7 @@ HTTPParser::HTTPParser() {}
 
 HTTPParser::~HTTPParser() {}
 
-HTTPRequest& HTTPParser::parse(std::string request_message)
-{
+HTTPRequest& HTTPParser::parse(std::string request_message) {
     std::string::iterator it =
         std::find(request_message.begin(), request_message.end(), '\n');
     std::string line(request_message.begin(), it);
@@ -15,12 +14,10 @@ HTTPRequest& HTTPParser::parse(std::string request_message)
     std::istringstream iss(line);
     std::string        method, uri;
     iss >> method >> uri;
-    if (method.empty())
-    {
+    if (method.empty()) {
         std::cout << "get method error" << std::endl;
     }
-    if (uri.empty())
-    {
+    if (uri.empty()) {
         std::cout << "get uri error" << std::endl;
     }
     HTTPRequest* req = new HTTPRequest(method, uri);

--- a/src/HTTPRequest.cpp
+++ b/src/HTTPRequest.cpp
@@ -5,8 +5,7 @@
 #include <sys/types.h>
 
 HTTPRequest::HTTPRequest(std::string method, std::string uri)
-    : method_(method), uri_(uri)
-{}
+    : method_(method), uri_(uri) {}
 
 HTTPRequest::~HTTPRequest() {}
 

--- a/src/HTTPResponse.cpp
+++ b/src/HTTPResponse.cpp
@@ -5,38 +5,29 @@
 
 HTTPResponse::HTTPResponse(int sock, int status_code, std::string header,
                            std::string body)
-    : sock_(sock), status_code_(status_code), header_(header), body_(body)
-{}
+    : sock_(sock), status_code_(status_code), header_(header), body_(body) {}
 
 HTTPResponse::~HTTPResponse() {}
 
-void HTTPResponse::create()
-{
+void HTTPResponse::create() {
     // 文字列で扱って大丈夫？バイナリの可能性は？
     // TODO:レスポンスのサイズをつくる
 
-    if (status_code_ == 200)
-    {
+    if (status_code_ == 200) {
         response_message_ =
             "HTTP/1.1 200 OK\r\n" + header_ + "\r\n\r\n" + body_;
-    }
-    else if (status_code_ == 404)
-    {
+    } else if (status_code_ == 404) {
         response_message_ = "HTTP1.1 404 No Found\r\n" + header_ + "\r\n";
-    }
-    else
-    {
+    } else {
         std::cout << "Not support status" << status_code_ << std::endl;
     }
     message_size_ = response_message_.size();
 }
 
-void HTTPResponse::sendMessage()
-{
+void HTTPResponse::sendMessage() {
     std::cout << "<<message>>\n" << response_message_ << std::endl;
     int ret = send(sock_, response_message_.c_str(), message_size_, 0);
-    if (ret == -1)
-    {
+    if (ret == -1) {
         std::cout << "send error" << std::endl;
     }
 }

--- a/src/ServerSocket.cpp
+++ b/src/ServerSocket.cpp
@@ -7,11 +7,9 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-ServerSocket::ServerSocket()
-{
+ServerSocket::ServerSocket() {
     sock_ = socket(AF_INET, SOCK_STREAM, 0);
-    if (sock_ == -1)
-    {
+    if (sock_ == -1) {
         std::cout << "socket error" << std::endl;
     }
     addr_ = SocketAddress();
@@ -19,11 +17,9 @@ ServerSocket::ServerSocket()
 
 ServerSocket::~ServerSocket() { close(sock_); }
 
-void ServerSocket::bindSocket()
-{
+void ServerSocket::bindSocket() {
     if (bind(sock_, (const struct sockaddr*)&addr_.getSockaddr(),
-             sizeof(addr_.getSockaddr())) == -1)
-    {
+             sizeof(addr_.getSockaddr())) == -1) {
         std::cout << "bind error" << std::endl;
         perror("bind");
         close(sock_);
@@ -31,10 +27,8 @@ void ServerSocket::bindSocket()
     }
 }
 
-void ServerSocket::listenSocket()
-{
-    if (listen(sock_, MAX_QUE) == -1)
-    {
+void ServerSocket::listenSocket() {
+    if (listen(sock_, MAX_QUE) == -1) {
         std::cout << "listen error" << std::endl;
         perror("bind");
         close(sock_);

--- a/src/SocketAddress.cpp
+++ b/src/SocketAddress.cpp
@@ -5,8 +5,7 @@
 
 const std::string SocketAddress::SERVER_ADDR = "127.0.0.1";
 
-SocketAddress::SocketAddress()
-{
+SocketAddress::SocketAddress() {
     std::memset(&socket_addr_, 0, sizeof(struct sockaddr_in));
     socket_addr_.sin_family = AF_INET;
     socket_addr_.sin_port   = htons(static_cast<unsigned short>(SERVER_PORT));

--- a/src/WebServ.cpp
+++ b/src/WebServ.cpp
@@ -8,10 +8,10 @@
 #include "HTTPResponse.hpp"
 #include "WebServ.hpp"
 
-#include <sys/select.h>
 #include <poll.h>
-#include <unistd.h>
 #include <sys/event.h>
+#include <sys/select.h>
+#include <unistd.h>
 
 #define BUF_SIZE 1024
 
@@ -19,18 +19,17 @@ WebServ::WebServ() {}
 
 WebServ::~WebServ() { delete s_sock_; }
 
-void WebServ::run()
-{
+void WebServ::run() {
     _serverSocketRun();
 
     // int ret;
-    int kq;
+    int           kq;
     struct kevent kev;
 
     kq = kqueue();
     if (kq == -1) {
-      perror("kqueue");
-      exit(1);
+        perror("kqueue");
+        exit(1);
     }
     EV_SET(&kev, s_sock_->getSocket(), EVFILT_READ, EV_ADD, 0, 0, NULL);
     // // ret = kevent(kq, &kev, 1, NULL, 0, NULL);
@@ -38,87 +37,78 @@ void WebServ::run()
     //   perror("kevent");
     //   exit(1);
     // }
-    while (true)
-    {
-       int n;
-       char buf[BUF_SIZE];
-       int sock;
+    while (true) {
+        int  n;
+        char buf[BUF_SIZE];
+        int  sock;
 
-       n = kevent(kq, &kev, 1, &kev, 1, NULL);
+        n = kevent(kq, &kev, 1, &kev, 1, NULL);
 
-       if (n == -1) {
-         perror("kevent");
-         exit(1);
-       }
-       if (n > 0) {
-         if ((int)kev.ident == s_sock_->getSocket()){
-           int acc = accept(kev.ident, NULL, NULL);
-           std::cout << acc << std::endl;
-           if (acc != -1){
-             EV_SET(&kev, acc, EVFILT_READ, EV_ADD, 0, 0, NULL);
-             n = kevent(kq, &kev, 1, NULL, 0, NULL);
-             if (n == -1) {
-               perror("kevent");
-               exit(1);
-             }
-           }
-         } else {
-           sock = kev.ident;
-           int recv_res = recv(sock, buf, sizeof(buf), 0);
-           if (recv_res == 0) {
-             close(sock);
-             continue ;
-           }
-          // メッセージをパースしてHTTPRequestを作る
-          HTTPParser  parser;
-          HTTPRequest req = parser.parse(std::string(buf));
-
-          if (req.getMethod() == "GET")
-          {
-              if (req.getURI() == "/")
-              {
-                  req.setURI(std::string("/index.html"));
-              }
-
-              // uriで指定されたファイルを読み取る
-              std::ifstream ifs(req.getURI().erase(0, 1));
-              std::string   tmp, file_content;
-              if (ifs.fail())
-              {
-                  std::cout << "fail open file" << std::endl;
-                  return;
-              }
-              while (std::getline(ifs, tmp))
-              {
-                  file_content += tmp + "\n";
-              }
-
-              // レスポンスヘッダーを作る
-              std::ostringstream oss;
-              std::string        length;
-              oss << file_content.length() << std::flush;
-              length = oss.str();
-              std::string  header("Content-Length: " + length);
-              HTTPResponse response(sock, 200, header,
-                                    file_content);
-
-              // レスポンスを作成して送信
-              response.create();
-              response.sendMessage();
-          }
-          else
-          {
-              // 404
-          }
+        if (n == -1) {
+            perror("kevent");
+            exit(1);
         }
-      }
+        if (n > 0) {
+            if ((int)kev.ident == s_sock_->getSocket()) {
+                int acc = accept(kev.ident, NULL, NULL);
+                std::cout << acc << std::endl;
+                if (acc != -1) {
+                    EV_SET(&kev, acc, EVFILT_READ, EV_ADD, 0, 0, NULL);
+                    n = kevent(kq, &kev, 1, NULL, 0, NULL);
+                    if (n == -1) {
+                        perror("kevent");
+                        exit(1);
+                    }
+                }
+            } else {
+                sock         = kev.ident;
+                int recv_res = recv(sock, buf, sizeof(buf), 0);
+                if (recv_res == 0) {
+                    close(sock);
+                    continue;
+                }
+                // メッセージをパースしてHTTPRequestを作る
+                HTTPParser  parser;
+                HTTPRequest req = parser.parse(std::string(buf));
+
+                if (req.getMethod() == "GET") {
+                    if (req.getURI() == "/") {
+                        req.setURI(std::string("/index.html"));
+                    }
+
+                    // uriで指定されたファイルを読み取る
+                    std::ifstream ifs(req.getURI().erase(0, 1));
+                    std::string   tmp, file_content;
+                    if (ifs.fail()) {
+                        std::cout << "fail open file" << std::endl;
+                        return;
+                    }
+                    while (std::getline(ifs, tmp)) {
+                        file_content += tmp + "\n";
+                    }
+
+                    // レスポンスヘッダーを作る
+                    std::ostringstream oss;
+                    std::string        length;
+                    oss << file_content.length() << std::flush;
+                    length = oss.str();
+                    std::string  header("Content-Length: " + length);
+                    HTTPResponse response(sock, 200, header, file_content);
+
+                    // レスポンスを作成して送信
+                    response.create();
+                    response.sendMessage();
+                } else {
+                    // 404
+                }
+            }
+        }
         // close
     }
     // close
 }
 
-void WebServ::_serverSocketRun()
-{
+void WebServ::_serverSocketRun() {
     /* ServerSocket* s_sock_ = new ServerSocket(); */
     s_sock_ = new ServerSocket();
     s_sock_->bindSocket();

--- a/src/WebServ.cpp
+++ b/src/WebServ.cpp
@@ -23,90 +23,94 @@ void WebServ::run()
 {
     _serverSocketRun();
 
-    int ret;
-      int kq;
-      struct kevent kev;
+    // int ret;
+    int kq;
+    struct kevent kev;
 
-      kq = kqueue();
-      if (kq == -1) {
-        perror("kqueue");
-        exit(1);
-      }
-      EV_SET(&kev, s_sock_->getSocket(), EVFILT_READ, EV_ADD, 0, 0, NULL);
-      ret = kevent(kq, &kev, 1, NULL, 0, NULL);
-      if (ret == -1) {
-        perror("kevent");
-        exit(1);
-      }
+    kq = kqueue();
+    if (kq == -1) {
+      perror("kqueue");
+      exit(1);
+    }
+    EV_SET(&kev, s_sock_->getSocket(), EVFILT_READ, EV_ADD, 0, 0, NULL);
+    // // ret = kevent(kq, &kev, 1, NULL, 0, NULL);
+    // if (ret == -1) {
+    //   perror("kevent");
+    //   exit(1);
+    // }
     while (true)
     {
        int n;
        char buf[BUF_SIZE];
        int sock;
 
-       n = kevent(kq, NULL, 0, &kev, 1, NULL);
+       n = kevent(kq, &kev, 1, &kev, 1, NULL);
 
        if (n == -1) {
          perror("kevent");
          exit(1);
        }
-       if ((int)kev.ident == s_sock_->getSocket()){
-         int acc = accept(kev.ident, NULL, NULL);
-         if (acc != -1){
-           EV_SET(&kev, acc, EVFILT_READ, EV_ADD, 0, 0, NULL);
-           n = kevent(kq, &kev, 1, NULL, 0, NULL);
-           if (n == -1) {
-             perror("kevent");
-             exit(1);
+       if (n > 0) {
+         if ((int)kev.ident == s_sock_->getSocket()){
+           int acc = accept(kev.ident, NULL, NULL);
+           std::cout << acc << std::endl;
+           if (acc != -1){
+             EV_SET(&kev, acc, EVFILT_READ, EV_ADD, 0, 0, NULL);
+             n = kevent(kq, &kev, 1, NULL, 0, NULL);
+             if (n == -1) {
+               perror("kevent");
+               exit(1);
+             }
            }
-         }
-       } else {
-         sock = kev.ident;
-         printf("ディスクリプタ %d 番が読み込み可能です。\n", sock);
-         recv(sock, buf, sizeof(buf), 0);
+         } else {
+           sock = kev.ident;
+           int recv_res = recv(sock, buf, sizeof(buf), 0);
+           if (recv_res == 0) {
+             close(sock);
+             continue ;
+           }
+          // メッセージをパースしてHTTPRequestを作る
+          HTTPParser  parser;
+          HTTPRequest req = parser.parse(std::string(buf));
 
-        // メッセージをパースしてHTTPRequestを作る
-        HTTPParser  parser;
-        HTTPRequest req = parser.parse(std::string(buf));
+          if (req.getMethod() == "GET")
+          {
+              if (req.getURI() == "/")
+              {
+                  req.setURI(std::string("/index.html"));
+              }
 
-        if (req.getMethod() == "GET")
-        {
-            if (req.getURI() == "/")
-            {
-                req.setURI(std::string("/index.html"));
-            }
+              // uriで指定されたファイルを読み取る
+              std::ifstream ifs(req.getURI().erase(0, 1));
+              std::string   tmp, file_content;
+              if (ifs.fail())
+              {
+                  std::cout << "fail open file" << std::endl;
+                  return;
+              }
+              while (std::getline(ifs, tmp))
+              {
+                  file_content += tmp + "\n";
+              }
 
-            // uriで指定されたファイルを読み取る
-            std::ifstream ifs(req.getURI().erase(0, 1));
-            std::string   tmp, file_content;
-            if (ifs.fail())
-            {
-                std::cout << "fail open file" << std::endl;
-                return;
-            }
-            while (std::getline(ifs, tmp))
-            {
-                file_content += tmp + "\n";
-            }
+              // レスポンスヘッダーを作る
+              std::ostringstream oss;
+              std::string        length;
+              oss << file_content.length() << std::flush;
+              length = oss.str();
+              std::string  header("Content-Length: " + length);
+              HTTPResponse response(sock, 200, header,
+                                    file_content);
 
-            // レスポンスヘッダーを作る
-            std::ostringstream oss;
-            std::string        length;
-            oss << file_content.length() << std::flush;
-            length = oss.str();
-            std::string  header("Content-Length: " + length);
-            HTTPResponse response(sock, 200, header,
-                                  file_content);
-
-            // レスポンスを作成して送信
-            response.create();
-            response.sendMessage();
+              // レスポンスを作成して送信
+              response.create();
+              response.sendMessage();
+          }
+          else
+          {
+              // 404
+          }
         }
-        else
-        {
-            // 404
-        }
-
       }
         // close
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,6 @@
 #include "WebServ.hpp"
 
-int main()
-{
+int main() {
     WebServ serv;
     serv.run();
     return 0;


### PR DESCRIPTION
## やったこと
- 関数の開始や、if/else のブロック`{}`で1行使用していたのを、行末に書くように変更。
- ファイルに適応
```cpp
// before
int hoge()
{
  if (true)
  {
    //
  }
  else 
  {
    //
  }
  return 0;
}

// after
int hoge() {
  if (true) {
    //
  } else {
    //
  }
  return 0;
}
```

## やらないこと

- 何か不便なことがあれば、適宜修正

## その他

- kqueueのコミットも巻き込んでいますが、動作に支障はないです。

## issues

about : #4 