### PR TITLE
:recycle : clang-tidy 修正

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,9 +16,9 @@ CheckOptions:
     value:           lower_case
   - key:             readability-identifier-naming.PrivateMemberSuffix
     value:           _
+  - key:             readability-identifier-naming.ProtectedMemberSuffix
+    value:           _
   - key:             readability-identifier-naming.PublicMethodCase
     value:           camelBack
-  - key:             readability-identifier-naming.privatemethodcase
-    value:           lower_case
-  - key:             readability-identifier-naming.PrivateMethodSuffix
-    value:           _
+  - key:             readability-identifier-naming.PrivateMethodCase
+    value:           camelBack

--- a/include/ServerSocket.hpp
+++ b/include/ServerSocket.hpp
@@ -12,7 +12,7 @@ private:
     SocketAddress addr_;
 
 public:
-    static const unsigned short MAX_QUE = 1024;
+    static const unsigned short max_que = 1024;
     ServerSocket();
     ~ServerSocket();
 

--- a/include/SocketAddress.hpp
+++ b/include/SocketAddress.hpp
@@ -10,8 +10,8 @@ private:
     struct sockaddr_in socket_addr_;
 
 public:
-    static const unsigned short SERVER_PORT = 4242;
-    static const std::string    SERVER_ADDR;
+    static const unsigned short server_port = 4242;
+    static const std::string    server_addr;
     SocketAddress();
     ~SocketAddress();
 

--- a/include/WebServ.hpp
+++ b/include/WebServ.hpp
@@ -14,7 +14,7 @@ private:
     ServerSocket* s_sock_;
 
 private:
-    void _serverSocketRun();
+    void serverSocketRun();
 };
 
 #endif

--- a/src/ServerSocket.cpp
+++ b/src/ServerSocket.cpp
@@ -28,7 +28,7 @@ void ServerSocket::bindSocket() {
 }
 
 void ServerSocket::listenSocket() {
-    if (listen(sock_, MAX_QUE) == -1) {
+    if (listen(sock_, max_que) == -1) {
         std::cout << "listen error" << std::endl;
         perror("bind");
         close(sock_);

--- a/src/SocketAddress.cpp
+++ b/src/SocketAddress.cpp
@@ -3,13 +3,13 @@
 #include <arpa/inet.h>
 #include <cstring>
 
-const std::string SocketAddress::SERVER_ADDR = "127.0.0.1";
+const std::string SocketAddress::server_addr = "127.0.0.1";
 
 SocketAddress::SocketAddress() {
     std::memset(&socket_addr_, 0, sizeof(struct sockaddr_in));
     socket_addr_.sin_family = AF_INET;
-    socket_addr_.sin_port   = htons(static_cast<unsigned short>(SERVER_PORT));
-    socket_addr_.sin_addr.s_addr = inet_addr(SERVER_ADDR.c_str());
+    socket_addr_.sin_port   = htons(static_cast<unsigned short>(server_port));
+    socket_addr_.sin_addr.s_addr = inet_addr(server_addr.c_str());
 }
 
 SocketAddress::~SocketAddress() {}

--- a/src/WebServ.cpp
+++ b/src/WebServ.cpp
@@ -20,7 +20,7 @@ WebServ::WebServ() {}
 WebServ::~WebServ() { delete s_sock_; }
 
 void WebServ::run() {
-    _serverSocketRun();
+    serverSocketRun();
 
     // int ret;
     int           kq;
@@ -108,7 +108,7 @@ void WebServ::run() {
     // close
 }
 
-void WebServ::_serverSocketRun() {
+void WebServ::serverSocketRun() {
     /* ServerSocket* s_sock_ = new ServerSocket(); */
     s_sock_ = new ServerSocket();
     s_sock_->bindSocket();


### PR DESCRIPTION


## やったこと

- privateなメソッドはlowerCamel(先頭小文字)、publicなメソッドはUpperCamel(先頭大文字)に変更

```cpp
// before
class Hoge{
private:
    hogeHoge();
};

// after
class Hoge{
private:
    HogeHoge();
}
```

## 動作確認

- 動作支障なし

## その他

## issues
