### PR TITLE
request parse途中 & google test動かすためにMakefile等変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,18 @@ VPATH     := src: \
 			src/socket \
 			src/event
 
-SRCS      := main.cpp \
-			EventActions.cpp \
-			HTTPParser.cpp \
-			HTTPRequest.cpp \
-			HTTPResponse.cpp \
+TESTSRCS  := EventActions.cpp \
 			ListeningSocket.cpp \
-			StreamSocket.cpp
+			StreamSocket.cpp \
+			HTTPRequest.cpp \
+			HTTPParser.cpp \
+			HTTPResponse.cpp
+
+SRCS := main.cpp \
+			$(TESTSRCS)
 
 OBJS      := $(addprefix $(OBJDIR)/, $(notdir $(SRCS:.cpp=.o)))
+TESTOBJS  := $(addprefix $(OBJDIR)/, $(notdir $(TESTSRCS:.cpp=.o)))
 DPS       := $(addprefix $(DPSDIR)/, $(notdir $(SRCS:.o=.d)))
 
 RM        := rm -rf
@@ -31,7 +34,7 @@ RM        := rm -rf
 all: makedir $(NAME)
 
 $(NAME): $(OBJS)
-	$(CXX) $(CXXFLAGS) -o $(NAME) $(OBJS) $(LIBS)
+	$(CXX) $(CXXFLAGS) -o $(NAME) $(OBJS)
 
 $(OBJDIR)/%.o: %.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDE) -MMD -MP -MF $(DPSDIR)/$(notdir $(<:.cpp=.d)) -c $< -o $@
@@ -77,7 +80,7 @@ $(gtest):
 	mv googletest-release-1.11.0 $(gtestdir)
 
 test_compile = clang++ -std=c++11 \
-	$(testdir)/gtest.cpp $(gtestdir)/googletest-release-1.11.0/googletest/src/gtest_main.cc $(gtestdir)/gtest/gtest-all.cc ./src/request/HTTPRequest.cpp \
+	$(testdir)/gtest.cpp $(gtestdir)/googletest-release-1.11.0/googletest/src/gtest_main.cc $(gtestdir)/gtest/gtest-all.cc $(TESTOBJS) \
 	-g -fsanitize=address -fsanitize=undefined -fsanitize=leak \
 	-I$(gtestdir) $(INCLUDE) -lpthread -o tester
 
@@ -85,7 +88,10 @@ test_compile = clang++ -std=c++11 \
 gtest: $(gtest)
 	$(test_compile)
 	./tester
-# ./tester # --gtest_filter=Vector.other
+
+gtestlist:
+	@./tester --gtest_list_tests
+	@echo "\nRUN ./tester --gtest_fileter=(TESTCASE).(TESTNAME)"
 
 .PHONY: cleangtest
 cleangtest:

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ $(gtest):
 	mv googletest-release-1.11.0 $(gtestdir)
 
 test_compile = clang++ -std=c++11 \
-	$(testdir)/gtest.cpp $(gtestdir)/googletest-release-1.11.0/googletest/src/gtest_main.cc $(gtestdir)/gtest/gtest-all.cc \
+	$(testdir)/gtest.cpp $(gtestdir)/googletest-release-1.11.0/googletest/src/gtest_main.cc $(gtestdir)/gtest/gtest-all.cc ./src/request/HTTPRequest.cpp \
 	-g -fsanitize=address -fsanitize=undefined -fsanitize=leak \
 	-I$(gtestdir) $(INCLUDE) -lpthread -o tester
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,6 @@
 #include "Socket.hpp"
 #include "StreamSocket.hpp"
 
-std::map<int, ListeningSocket*> ListeningSocket::all_listener;
 
 int main(void) {
     // Event Action set up

--- a/src/request/HTTPRequest.cpp
+++ b/src/request/HTTPRequest.cpp
@@ -1,8 +1,26 @@
 #include "HTTPRequest.hpp"
-#include <iostream>
-#include <stdexcept>
+
 #include <sys/socket.h>
 #include <sys/types.h>
+
+#include <exception>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+
+#define GREEN "\033[32m"
+#define RED "\033[31m"
+#define RESET "\033[39m"
+
+std::set<std::string> HTTPRequest::methods;
+
+const std::string HTTPRequest::crlf = "\r\n";
+
+HTTPRequest::HTTPRequest(const std::string& row) : row_(row), status_(200) {
+    HTTPRequest::methods.insert("GET");
+    parse();
+}
 
 HTTPRequest::HTTPRequest(std::string method, std::string uri)
     : method_(method), uri_(uri) {}
@@ -10,6 +28,118 @@ HTTPRequest::HTTPRequest(std::string method, std::string uri)
 HTTPRequest::~HTTPRequest() {}
 
 std::string& HTTPRequest::GetMethod() { return method_; }
+
 std::string& HTTPRequest::GetURI() { return uri_; }
 
+std::string& HTTPRequest::GetVersion() { return version_; }
+
+int HTTPRequest::GetStatus() { return status_; }
+
+std::string HTTPRequest::GetHeaderValue(std::string key) {
+    return headers_[key];
+}
+
+std::map<std::string, std::string> HTTPRequest::GetHeaders() {
+    return headers_;
+}
+
 void HTTPRequest::SetURI(std::string uri) { uri_ = uri; }
+
+void HTTPRequest::parseFirstline(std::string line) {
+    std::istringstream iss(line);
+    std::string        method, uri;
+    std::string        version = "HTTP/1.1";
+
+    iss >> method >> uri >> version;
+
+    if (uri == "/") {
+        uri = "index.html";
+    }
+
+    // バリデート
+    if (method.empty() || uri.empty()) {
+        throwErrorBadrequest("error request line");
+    }
+
+    if (methods.find(method) == methods.end()) {
+        throwErrorBadrequest("error request line");
+    }
+    // バージョンが1.1以外なら505
+
+    method_  = method;
+    uri_     = uri;
+    version_ = version;
+}
+
+void HTTPRequest::parseHeaderLine(std::string line) {
+    std::cout << GREEN << "line: " << line << RESET << std::endl;
+    std::size_t pos = line.find(":");
+    std::string key, value;
+    key = line.substr(0, pos);
+    if (pos != line.npos) {
+        value = line.substr(pos + 1, line.size() - pos);
+    }
+
+    // TODO
+    // keyにスペースあるとNG
+
+    // valueの前後のスペースはtrim
+    // valueの間にスペースはNG
+
+    headers_.insert(std::make_pair(key, value));
+}
+
+bool HTTPRequest::isLastLine(std::string& str) {
+    const std::size_t crlf_size    = crlf.size();
+    std::size_t       line_end_pos = str.find(crlf);
+    std::string       next_line    = str.substr(line_end_pos + crlf_size);
+
+    return next_line.size() >= crlf_size &&
+           next_line.substr(0, crlf_size) == crlf;
+}
+
+void HTTPRequest::parseBody(std::string body) {
+    std::cout << "body: " << body << std::endl;
+    if (body.empty()) {
+        std::cout << "empty body" << std::endl;
+        return;
+    }
+    if (body.size() >= crlf.size() && body.substr(0, crlf.size()) == crlf) {
+        // 改行が3つ連続していた場合
+        throwErrorBadrequest("error body");
+    }
+    body_ = body;
+}
+
+void HTTPRequest::throwErrorBadrequest(std::string err_message) {
+    status_ = 400;
+    throw std::runtime_error(err_message);
+}
+
+void HTTPRequest::parse() {
+    try {
+        std::size_t line_end_pos = row_.find(crlf);
+        if (line_end_pos == row_.npos) {
+            throwErrorBadrequest("error request line");
+        }
+
+        parseFirstline(row_.substr(0, line_end_pos));
+
+        std::string str = row_;
+        while (status_ == 200 && !isLastLine(str)) {
+            std::size_t line_start_pos = line_end_pos + crlf.size();
+            str                        = str.substr(line_start_pos);
+            line_end_pos               = str.find(crlf);
+
+            if (line_end_pos == row_.npos) {
+                throwErrorBadrequest("missing crlf");
+            }
+            parseHeaderLine(str.substr(0, line_end_pos));
+        }
+        std::string body =
+            str.substr(str.find(crlf) + crlf.size() + crlf.size());
+        parseBody(body);
+    } catch (std::runtime_error& e) {
+        std::cout << RED << "exception: " << e.what() << RESET << std::endl;
+    } catch (std::exception& e) {}
+}

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -1,22 +1,44 @@
 #ifndef HTTPREQUEST_HPP
 #define HTTPREQUEST_HPP
-#include "StreamSocket.hpp"
+#include <map>
+#include <set>
 #include <string>
 
 class HTTPRequest
 {
-private:
-    std::string request_message_;
-    std::string method_;
-    std::string uri_;
-    std::string body_;
-
 public:
+    HTTPRequest(const std::string& row);
     HTTPRequest(std::string method, std::string uri);
     ~HTTPRequest();
-    std::string& GetMethod();
-    std::string& GetURI();
-    void         SetURI(std::string uri);
+    std::string&                       GetMethod();
+    std::string&                       GetURI();
+    std::string&                       GetVersion();
+    int                                GetStatus();
+    std::map<std::string, std::string> GetHeaders();
+    std::string                        GetHeaderValue(std::string key);
+    void                               SetURI(std::string uri);
+
+    // 対応するメソッド一覧。仮でここで宣言
+    static std::set<std::string> methods;
+
+    static const std::string crlf;
+
+private:
+    std::string                        request_message_;
+    std::string                        method_;
+    std::string                        uri_;
+    std::string                        version_;
+    std::string                        body_;
+    std::string                        row_;
+    std::map<std::string, std::string> headers_;
+    int                                status_;
+
+    void parse();
+    void parseFirstline(std::string line);
+    void parseHeaderLine(std::string line);
+    void parseBody(std::string body);
+    bool isLastLine(std::string& str);
+    void throwErrorBadrequest(std::string err_message);
 };
 
 #endif

--- a/src/socket/ListeningSocket.cpp
+++ b/src/socket/ListeningSocket.cpp
@@ -12,6 +12,8 @@
 
 #include <iostream>
 
+std::map<int, ListeningSocket*> ListeningSocket::all_listener;
+
 ListeningSocket::ListeningSocket() { SetSocketType(Socket::LISTENING); }
 
 ListeningSocket::~ListeningSocket() {}

--- a/test/gtest.cpp
+++ b/test/gtest.cpp
@@ -7,4 +7,4 @@
 
 /* Include all tests files */
 
-#include "test.cpp"
+#include "request.cpp"

--- a/test/request.cpp
+++ b/test/request.cpp
@@ -1,0 +1,99 @@
+#include <gtest/gtest.h>
+
+#include "HTTPRequest.hpp"
+
+#define GREEN "\033[32m"
+#define RED "\033[31m"
+#define RESET "\033[39m"
+
+using namespace std;
+
+struct testcase {
+    std::string message;
+    int         expect_status;
+    std::string exepct_method;
+    std::string expect_uri;
+    std::string expect_version;
+    std::string expect_host;
+};
+
+void printMessageIfFailed(std::string message, bool failed) {
+    if (failed) {
+        cout << RED << "\n[FAILED REQUEST]:\n"
+             << RESET << message << "\n"
+             << endl;
+    }
+}
+
+void testRequest(testcase* test) {
+    HTTPRequest req(test->message);
+
+    ASSERT_EQ(test->expect_status, req.GetStatus());
+    EXPECT_EQ(test->exepct_method, req.GetMethod());
+    EXPECT_EQ(test->expect_uri, req.GetURI());
+    EXPECT_EQ(test->expect_version, req.GetVersion());
+    EXPECT_EQ(test->expect_host, req.GetHeaderValue("Host"));
+}
+
+TEST(HTTPRequest, Simple) {
+    testcase t = { "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
+                   200,
+                   "GET",
+                   "index.html",
+                   "HTTP/1.1",
+                   "localhost" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, NotSpecifyVersion) {
+    testcase t = { "GET /\r\nHost: localhost\r\n\r\n",
+                   200,
+                   "GET",
+                   "index.html",
+                   "HTTP/1.1",
+                   "localhost" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, SpecifyTarget) {
+    testcase t = { "GET hoge\r\nHost: localhost\r\n\r\n",
+                   200,
+                   "GET",
+                   "hoge",
+                   "HTTP/1.1",
+                   "localhost" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, LowercaseMethod) {
+    testcase t = { "get / HTTP/1.1\r\n\r\n", 400, "", "", "", "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, NoHost) {
+    testcase t = { "GET / HTTP/1.1\r\n\r\n", 400, "", "", "", "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, UnsupportedMethod) {
+    testcase t = {
+        "HOGE / HTTP/1.1\r\nHost: localhost\r\n\r\n", 405, "", "", "",
+    };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, VersionNotSupported) {
+    testcase t = { "GET / HTTP/3.0\r\nHost: localhost\r\n\r\n", 505, "", "",
+                   "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, KeyIncludeSpace) {}
+


### PR DESCRIPTION
requestのパースは中途半端ですが、google test動かすためにMakefile等に変更が生まれたので早めにプルリク出しました。
## やったこと

- requestのパース（途中）
  - ヘッダーの1行目、ヘッダーの2行目以降、ボディに分割して別の関数に処理を投げてます。
  - それぞれの細かいバリデート、正規化等はまだです。
- googletest作成
  -  SRCSをTESTSRCSとmain.cppに分割して、googletestの方ではTESTSRCSでコンパイルするようにしました。
  - それに伴い、ListeningSocketクラスの定数をmain.cppで初期化してたのをListeningSocket.cppに移動しました。

## 動作確認
- 今までできていたことは問題なく動くと思います。
- コンパイルしてオブジェクトファイルがある状態で`make gtest`でテスト実行

## その他

- 対応するメソッド一覧をsetで定義してるのですがコンストラクタで中身を入れる必要があるのが面倒なので、arrayに変更しようと思ってます。
- HTTPRequest.cppでエスケープシーケンスをdefineしてるのもあとで消します。
- MakefileのTESTSRCSって名前が微妙な気もするので、いい名前があったら教えてください。

## issues

about : #26 #24 

