### PR TITLE
:up: clang-format 修正

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -31,7 +31,7 @@ BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
   AfterCaseLabel:  false
-  AfterClass:      true
+  AfterClass:      false
   AfterControlStatement: Never
   AfterEnum:       false
   AfterFunction:   false

--- a/src/event/EventActions.hpp
+++ b/src/event/EventActions.hpp
@@ -7,8 +7,7 @@
 #include "Socket.hpp"
 
 class Socket;
-class EventActions
-{
+class EventActions {
 public:
     EventActions();
     ~EventActions();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,6 @@
 #include "Socket.hpp"
 #include "StreamSocket.hpp"
 
-
 int main(void) {
     // Event Action set up
     EventActions event_actions;

--- a/src/request/HTTPParser.hpp
+++ b/src/request/HTTPParser.hpp
@@ -5,8 +5,7 @@
 #include <string>
 
 class HTTPRequest;
-class HTTPParser
-{
+class HTTPParser {
 private:
     /* data */
 public:

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -4,8 +4,7 @@
 #include <set>
 #include <string>
 
-class HTTPRequest
-{
+class HTTPRequest {
 public:
     HTTPRequest(const std::string& row);
     HTTPRequest(std::string method, std::string uri);

--- a/src/response/HTTPResponse.hpp
+++ b/src/response/HTTPResponse.hpp
@@ -2,8 +2,7 @@
 #define HTTPRESPONSE_HPP
 #include <string>
 
-class HTTPResponse
-{
+class HTTPResponse {
 public:
     HTTPResponse(int sock, int status_code, std::string header,
                  std::string body);

--- a/src/socket/ListeningSocket.hpp
+++ b/src/socket/ListeningSocket.hpp
@@ -6,8 +6,7 @@
 
 #include "Socket.hpp"
 
-class ListeningSocket : public Socket
-{
+class ListeningSocket : public Socket {
 public:
     ListeningSocket();
     virtual ~ListeningSocket();

--- a/src/socket/Socket.hpp
+++ b/src/socket/Socket.hpp
@@ -5,8 +5,7 @@
 #include <netinet/in.h>
 
 class EventActions;
-class Socket
-{
+class Socket {
 public:
     enum SOCKET_TYPE {
         LISTENING,
@@ -17,7 +16,7 @@ public:
     Socket(int sock) : sock_fd_(sock) {}
     virtual ~Socket() {}
 
-    void       SetSocketType(SOCKET_TYPE type) { type_ = type; }
+    void        SetSocketType(SOCKET_TYPE type) { type_ = type; }
     SOCKET_TYPE GetSocketType() { return type_; }
 
     void SetSocketFd(const int& sock) { sock_fd_ = sock; }
@@ -31,7 +30,7 @@ public:
 
 protected:
     int                sock_fd_;
-    SOCKET_TYPE         type_;
+    SOCKET_TYPE        type_;
     struct sockaddr_in addr_;
 
     EventActions* actions_;

--- a/src/socket/StreamSocket.hpp
+++ b/src/socket/StreamSocket.hpp
@@ -10,8 +10,7 @@
 class HTTPParser;
 class HTTPRequest;
 class HTTPResponse;
-class StreamSocket : public Socket
-{
+class StreamSocket : public Socket {
 public:
     StreamSocket();
     virtual ~StreamSocket();


### PR DESCRIPTION
class宣言時ブロックの開始を行末へ

## やったこと
```hpp
// before
class Hoge
{
};

// after
class Hoge {
};
```

## 動作確認

- フォーマットを全ての class に適応

## その他

- 既存のhppファイルは修正済みなので、改めてフォーマットを当てる必要はありません。
## issues
なし
