### PR TITLE
clang-tidy が動くように修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,11 @@ re: fclean all
 
 .PHONY: tidy
 tidy:
-	clang-tidy `find src include -type f` -- -I$(INCDIR)
+	clang-tidy `find src -type f` -- $(INCLUDE)
 
 .PHONY: tidy-fix
 tidy-fix:
-	clang-tidy `find src include -type f` --fix -- -I$(INCDIR)
+	clang-tidy `find src include -type f` --fix -- $(INCLUDE)
 
 ################# google test ####################
 


### PR DESCRIPTION
## やったこと

- clang-tidy が動くように修正

## やらないこと

- 特になし

## 動作確認

- `make tidy`、`make tidy-fix`が動く

## その他

## issues

about : #34 

close #34 
