### PR TITLE
Feature/http request parse

### DIFF
--- a/src/request/HTTPRequest.cpp
+++ b/src/request/HTTPRequest.cpp
@@ -11,10 +11,6 @@
 #include <sstream>
 #include <stdexcept>
 
-#define GREEN "\033[32m"
-#define RED "\033[31m"
-#define RESET "\033[39m"
-
 std::set<std::string> HTTPRequest::methods;
 
 const std::string HTTPRequest::crlf = "\r\n";
@@ -210,14 +206,6 @@ void HTTPRequest::parseHeaderLine(std::string line) {
     headers_.insert(std::make_pair(key, value));
 }
 
-void HTTPRequest::parseBody(std::string body) {
-    if (body.empty()) {
-        return;
-    }
-    varidateBody(body);
-    body_ = body;
-}
-
 bool HTTPRequest::hostExists() { return !GetHeaderValue("Host").empty(); }
 
 // 2行目以降のヘッダーをパース
@@ -236,6 +224,14 @@ void HTTPRequest::parseHeaderLines(std::string&           str,
     if (!hostExists()) {
         throwErrorBadrequest("no host");
     }
+}
+
+void HTTPRequest::parseBody(std::string body) {
+    if (body.empty()) {
+        return;
+    }
+    varidateBody(body);
+    body_ = body;
 }
 
 void HTTPRequest::parse() {
@@ -257,7 +253,7 @@ void HTTPRequest::parse() {
         varidateVersionNotSuppoted();
         varidateMethodNotAllowed();
     } catch (std::runtime_error& e) {
-        std::cout << RED << "exception: " << e.what() << RESET << std::endl;
+        // std::cout << "exception: " << e.what() << std::endl;
     } catch (std::exception& e) {}
 }
 
@@ -278,4 +274,3 @@ bool HTTPRequest::isdigit(std::string str) {
     }
     return true;
 }
-

--- a/src/request/HTTPRequest.cpp
+++ b/src/request/HTTPRequest.cpp
@@ -60,15 +60,6 @@ void HTTPRequest::varidateMethod(std::string& method) {
     }
 }
 
-bool HTTPRequest::isdigit(std::string str) {
-    for (std::string::iterator it = str.begin(); it != str.end(); it++) {
-        if (!std::isdigit(*it)) {
-            return false;
-        }
-    }
-    return true;
-}
-
 void HTTPRequest::varidateRequestTarget(std::string request_target) {
     if (request_target.empty()) {
         throwErrorBadrequest("error request target");
@@ -109,6 +100,7 @@ void HTTPRequest::varidateHTTPVersion(std::string version) {
     }
 }
 
+// リクエストの1行目をパースしてバリデート
 void HTTPRequest::parseFirstline(std::string line) {
     std::istringstream iss(line);
     std::string        method, request_target;
@@ -120,7 +112,6 @@ void HTTPRequest::parseFirstline(std::string line) {
         request_target = "index.html";
     }
 
-    // バリデート
     varidateMethod(method);
     varidateRequestTarget(request_target);
     varidateHTTPVersion(version);
@@ -173,7 +164,7 @@ void HTTPRequest::parseHeaderLine(std::string line) {
     }
 
     value = trimSpace(value);
-    if (value.find(crlf) != value.npos) {
+    if (value.find_first_of(crlf) != value.npos) {
         throwErrorBadrequest("error value");
     }
 
@@ -257,5 +248,14 @@ void HTTPRequest::parse() {
     } catch (std::runtime_error& e) {
         // std::cout << RED << "exception: " << e.what() << RESET << std::endl;
     } catch (std::exception& e) {}
+}
+
+bool HTTPRequest::isdigit(std::string str) {
+    for (std::string::iterator it = str.begin(); it != str.end(); it++) {
+        if (!std::isdigit(*it)) {
+            return false;
+        }
+    }
+    return true;
 }
 

--- a/src/request/HTTPRequest.cpp
+++ b/src/request/HTTPRequest.cpp
@@ -1,5 +1,6 @@
 #include "HTTPRequest.hpp"
 
+#include <algorithm>
 #include <cctype>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -165,9 +166,16 @@ void HTTPRequest::parseHeaderLine(std::string line) {
         throwErrorBadrequest("error token");
     }
 
+    // host->Host
+    std::transform(key.begin(), key.end(), key.begin(), ::tolower);
+    if (key.size() >= 1) {
+        key[0] = std::toupper(key[0]);
+    }
+
     value = trimSpace(value);
-    // OK: \t, \v, \f, \b
-    // NG: \r
+    if (value.find(crlf) != value.npos) {
+        throwErrorBadrequest("error value");
+    }
 
     headers_.insert(std::make_pair(key, value));
 }
@@ -251,4 +259,3 @@ void HTTPRequest::parse() {
     } catch (std::exception& e) {}
 }
 
-// TODO: keyをキャピタライズ

--- a/src/request/HTTPRequest.cpp
+++ b/src/request/HTTPRequest.cpp
@@ -68,8 +68,8 @@ void HTTPRequest::throwErrorVersionNotSupported(
     throw std::runtime_error(err_message);
 }
 
-void HTTPRequest::varidateMethod(const std::string& method) {
-    varidateToken(method);
+void HTTPRequest::validateMethod(const std::string& method) {
+    validateToken(method);
 
     for (std::string::const_iterator it = method.begin(); it != method.end();
          it++) {
@@ -79,21 +79,21 @@ void HTTPRequest::varidateMethod(const std::string& method) {
     }
 }
 
-void HTTPRequest::varidateBody(const std::string& body) {
+void HTTPRequest::validateBody(const std::string& body) {
     if (body.size() >= crlf_size && body.substr(0, crlf_size) == crlf) {
         // 改行が3つ連続していた場合
         throwErrorBadrequest("error body");
     }
 }
 
-void HTTPRequest::varidateRequestTarget(const std::string& request_target) {
+void HTTPRequest::validateRequestTarget(const std::string& request_target) {
     // TODO: バリデート
     if (request_target.empty()) {
         throwErrorBadrequest("error request target");
     }
 }
 
-void HTTPRequest::varidateHTTPVersion(const std::string& version) {
+void HTTPRequest::validateHTTPVersion(const std::string& version) {
     if (version.empty()) {
         throwErrorBadrequest("error HTTP version");
     }
@@ -131,7 +131,7 @@ void HTTPRequest::varidateHTTPVersion(const std::string& version) {
 // tchar          = "!" / "#" / "$" / "%" / "&" / "'" / "*"
 //               / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
 //               / DIGIT / ALPHA
-void HTTPRequest::varidateToken(const std::string& token) {
+void HTTPRequest::validateToken(const std::string& token) {
     if (token.empty()) {
         throwErrorBadrequest("empty token");
     }
@@ -144,13 +144,13 @@ void HTTPRequest::varidateToken(const std::string& token) {
     }
 }
 
-void HTTPRequest::varidateVersionNotSuppoted() {
+void HTTPRequest::validateVersionNotSuppoted() {
     if (HTTPVersion_ != "HTTP/1.1") {
         throwErrorVersionNotSupported();
     }
 }
 
-void HTTPRequest::varidateMethodNotAllowed() {
+void HTTPRequest::validateMethodNotAllowed() {
     if (methods.find(method_) == methods.end()) {
         throwErrorMethodNotAllowed();
     }
@@ -168,9 +168,9 @@ void HTTPRequest::parseFirstline(const std::string& line) {
         request_target = "index.html";
     }
 
-    varidateMethod(method);
-    varidateRequestTarget(request_target);
-    varidateHTTPVersion(version);
+    validateMethod(method);
+    validateRequestTarget(request_target);
+    validateHTTPVersion(version);
 
     method_         = method;
     request_target_ = request_target;
@@ -217,7 +217,7 @@ void HTTPRequest::parseHeaderLine(const std::string& line) {
         value = line.substr(pos + 1, line.size() - pos);
     }
 
-    varidateToken(key);
+    validateToken(key);
 
     // example: HOST -> Host
     std::transform(key.begin(), key.end(), key.begin(), ::tolower);
@@ -239,7 +239,7 @@ void HTTPRequest::parseBody(std::string& body) {
     if (body.empty()) {
         return;
     }
-    varidateBody(body);
+    validateBody(body);
     body_ = body;
 }
 
@@ -261,7 +261,6 @@ void HTTPRequest::parse() {
         std::string::size_type line_end_pos = mustFindCRLF(row_);
         parseFirstline(row_.substr(0, line_end_pos));
 
-        // TODO: line_end_posを渡さないでできるようにする
         std::string str = row_.substr(line_end_pos + crlf_size);
         parseHeaderLines(str);
 
@@ -269,8 +268,8 @@ void HTTPRequest::parse() {
         parseBody(body);
 
         // 400以外のエラー処理
-        varidateVersionNotSuppoted();
-        varidateMethodNotAllowed();
+        validateVersionNotSuppoted();
+        validateMethodNotAllowed();
     } catch (std::runtime_error& e) {
         std::cout << "exception: " << e.what() << std::endl;
     } catch (std::exception& e) {

--- a/src/request/HTTPRequest.cpp
+++ b/src/request/HTTPRequest.cpp
@@ -15,6 +15,8 @@ std::set<std::string> HTTPRequest::methods;
 
 const std::string HTTPRequest::crlf = "\r\n";
 
+const std::string::size_type HTTPRequest::crlf_size = crlf.size();
+
 HTTPRequest::HTTPRequest(const std::string& row)
     : row_(row), status_(status_ok) {
     HTTPRequest::methods.insert("GET");
@@ -78,7 +80,7 @@ void HTTPRequest::varidateMethod(const std::string& method) {
 }
 
 void HTTPRequest::varidateBody(const std::string& body) {
-    if (body.size() >= crlf.size() && body.substr(0, crlf.size()) == crlf) {
+    if (body.size() >= crlf_size && body.substr(0, crlf_size) == crlf) {
         // 改行が3つ連続していた場合
         throwErrorBadrequest("error body");
     }
@@ -243,12 +245,10 @@ void HTTPRequest::parseBody(std::string& body) {
 
 // 2行目以降のヘッダーをパース
 void HTTPRequest::parseHeaderLines(std::string& str) {
-    const std::string::size_type crlf_size = crlf.size();
-
     while (str.substr(0, crlf_size) != crlf) {
         std::string::size_type line_end_pos = mustFindCRLF(str);
         parseHeaderLine(str.substr(0, line_end_pos));
-        str = str.substr(line_end_pos + crlf.size());
+        str = str.substr(line_end_pos + crlf_size);
         mustFindCRLF(str);
     }
     if (!hostExists()) {
@@ -262,10 +262,10 @@ void HTTPRequest::parse() {
         parseFirstline(row_.substr(0, line_end_pos));
 
         // TODO: line_end_posを渡さないでできるようにする
-        std::string str = row_.substr(line_end_pos + crlf.size());
+        std::string str = row_.substr(line_end_pos + crlf_size);
         parseHeaderLines(str);
 
-        std::string body = str.substr(crlf.size());
+        std::string body = str.substr(crlf_size);
         parseBody(body);
 
         // 400以外のエラー処理

--- a/src/request/HTTPRequest.cpp
+++ b/src/request/HTTPRequest.cpp
@@ -84,7 +84,7 @@ void HTTPRequest::varidateBody(std::string body) {
 }
 
 void HTTPRequest::varidateRequestTarget(std::string request_target) {
-    // TODO
+    // TODO: バリデート
     if (request_target.empty()) {
         throwErrorBadrequest("error request target");
     }
@@ -137,6 +137,18 @@ void HTTPRequest::varidateToken(std::string token) {
         if (!std::isalnum(*it) && special.find(*it) == special.npos) {
             throwErrorBadrequest("error token");
         }
+    }
+}
+
+void HTTPRequest::varidateVersionNotSuppoted() {
+    if (HTTPVersion_ != "HTTP/1.1") {
+        throwErrorVersionNotSupported();
+    }
+}
+
+void HTTPRequest::varidateMethodNotAllowed() {
+    if (methods.find(method_) == methods.end()) {
+        throwErrorMethodNotAllowed();
     }
 }
 
@@ -237,19 +249,15 @@ void HTTPRequest::parse() {
 
         std::string str = row_;
         parseHeaderLines(str, line_end_pos);
-        std::string body =
-            str.substr(str.find(crlf) + crlf.size() + crlf.size());
+
+        std::string body = str.substr(str.find(crlf) + crlf.size() * 2);
         parseBody(body);
 
         // 400以外のエラー処理
-        if (HTTPVersion_ != "HTTP/1.1") {
-            throwErrorVersionNotSupported();
-        }
-        if (methods.find(method_) == methods.end()) {
-            throwErrorMethodNotAllowed();
-        }
+        varidateVersionNotSuppoted();
+        varidateMethodNotAllowed();
     } catch (std::runtime_error& e) {
-        // std::cout << RED << "exception: " << e.what() << RESET << std::endl;
+        std::cout << RED << "exception: " << e.what() << RESET << std::endl;
     } catch (std::exception& e) {}
 }
 

--- a/src/request/HTTPRequest.cpp
+++ b/src/request/HTTPRequest.cpp
@@ -123,8 +123,6 @@ void HTTPRequest::parseFirstline(std::string line) {
     varidateRequestTarget(request_target);
     varidateHTTPVersion(version);
 
-    // バージョンが1.1以外なら505
-
     method_         = method;
     request_target_ = request_target;
     HTTPVersion_    = version;
@@ -198,6 +196,8 @@ void HTTPRequest::throwErrorBadrequest(std::string err_message) {
     throw std::runtime_error(err_message);
 }
 
+bool HTTPRequest::hostExists() { return !GetHeaderValue("Host").empty(); }
+
 void HTTPRequest::parse() {
     try {
         std::string::size_type line_end_pos = row_.find(crlf);
@@ -218,10 +218,15 @@ void HTTPRequest::parse() {
             }
             parseHeaderLine(str.substr(0, line_end_pos));
         }
+        if (!hostExists()) {
+            throwErrorBadrequest("no host");
+        }
         std::string body =
             str.substr(str.find(crlf) + crlf.size() + crlf.size());
         parseBody(body);
     } catch (std::runtime_error& e) {
         std::cout << RED << "exception: " << e.what() << RESET << std::endl;
     } catch (std::exception& e) {}
+
+    // バージョンが1.1以外なら505
 }

--- a/src/request/HTTPRequest.cpp
+++ b/src/request/HTTPRequest.cpp
@@ -1,5 +1,6 @@
 #include "HTTPRequest.hpp"
 
+#include <cctype>
 #include <sys/socket.h>
 #include <sys/types.h>
 
@@ -23,13 +24,13 @@ HTTPRequest::HTTPRequest(const std::string& row) : row_(row), status_(200) {
 }
 
 HTTPRequest::HTTPRequest(std::string method, std::string uri)
-    : method_(method), uri_(uri) {}
+    : method_(method), request_target_(uri) {}
 
 HTTPRequest::~HTTPRequest() {}
 
 std::string& HTTPRequest::GetMethod() { return method_; }
 
-std::string& HTTPRequest::GetURI() { return uri_; }
+std::string& HTTPRequest::GetRequestTarget() { return request_target_; }
 
 std::string& HTTPRequest::GetVersion() { return version_; }
 
@@ -43,7 +44,19 @@ std::map<std::string, std::string> HTTPRequest::GetHeaders() {
     return headers_;
 }
 
-void HTTPRequest::SetURI(std::string uri) { uri_ = uri; }
+void HTTPRequest::SetURI(std::string uri) { request_target_ = uri; }
+
+void HTTPRequest::varidateMethod(std::string& method) {
+    if (method.empty() || !isToken(method)) {
+        throwErrorBadrequest("error method");
+    }
+
+    for (std::string::iterator it = method.begin(); it != method.end(); it++) {
+        if (!std::isupper(*it)) {
+            throwErrorBadrequest("error method");
+        }
+    }
+}
 
 void HTTPRequest::parseFirstline(std::string line) {
     std::istringstream iss(line);
@@ -57,21 +70,19 @@ void HTTPRequest::parseFirstline(std::string line) {
     }
 
     // バリデート
+    varidateMethod(method);
     if (method.empty() || uri.empty() || !isToken(method)) {
         throwErrorBadrequest("error request line");
     }
 
     // バージョンが1.1以外なら505
 
-    method_  = method;
-    uri_     = uri;
-    version_ = version;
+    method_         = method;
+    request_target_ = uri;
+    version_        = version;
 }
 
 // tokenとして適切な文字列か判定
-//
-// note: こういうのクラスのメソッドである意味がないからクラスの外に出したい
-// その場合、request/utils/isToken.cpp になる？
 bool HTTPRequest::isToken(std::string str) {
     const std::string special = "!#$%&'*+-.^_`|~";
     for (std::string::iterator it = str.begin(); it != str.end(); it++) {
@@ -82,9 +93,9 @@ bool HTTPRequest::isToken(std::string str) {
     return true;
 }
 
-// nginxはタブ入れると400になるけどrfc的にはスペースでもタブでも大丈夫そう
+// 前後のスペースをtrim
 std::string HTTPRequest::trimSpace(const std::string& str,
-                                   const std::string  trim_char_set = " \t") {
+                                   const std::string  trim_char_set = " ") {
     std::string            result;
     std::string::size_type left = str.find_first_not_of(trim_char_set);
 
@@ -107,10 +118,9 @@ void HTTPRequest::parseHeaderLine(std::string line) {
         throwErrorBadrequest("error token");
     }
 
-    // valueの前後のスペースはtrim
     value = trimSpace(value);
-
-    // valueの間にスペースはNG
+    // OK: \t, \v, \f, \b
+    // NG: \r
 
     headers_.insert(std::make_pair(key, value));
 }

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -64,9 +64,6 @@ private:
 
     bool isLastLine(std::string& str);
     bool isdigit(std::string str);
-
-    bool isSupportedMethod();
-    bool isSupportedVersion();
     bool hostExists();
 };
 

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -47,8 +47,9 @@ private:
     void parseHeaderLine(std::string line);
     void parseBody(std::string body);
 
-    std::string trimSpace(const std::string& string,
-                          const std::string  trim_char_set);
+    std::string            trimSpace(const std::string& string,
+                                     const std::string  trim_char_set);
+    std::string::size_type mustFindCRLF(std::string& str);
 
     void throwErrorBadrequest(std::string err_message);
     void throwErrorMethodNotAllowed(std::string err_message);

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -59,6 +59,8 @@ private:
     void varidateHTTPVersion(std::string version);
     void varidateToken(std::string token);
     void varidateBody(std::string body);
+    void varidateVersionNotSuppoted();
+    void varidateMethodNotAllowed();
 
     bool isLastLine(std::string& str);
     bool isdigit(std::string str);

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -51,13 +51,13 @@ private:
     void throwErrorMethodNotAllowed(const std::string err_message);
     void throwErrorVersionNotSupported(const std::string err_message);
 
-    void varidateMethod(const std::string& method);
-    void varidateRequestTarget(const std::string& request_target);
-    void varidateHTTPVersion(const std::string& version);
-    void varidateToken(const std::string& token);
-    void varidateBody(const std::string& body);
-    void varidateVersionNotSuppoted();
-    void varidateMethodNotAllowed();
+    void validateMethod(const std::string& method);
+    void validateRequestTarget(const std::string& request_target);
+    void validateHTTPVersion(const std::string& version);
+    void validateToken(const std::string& token);
+    void validateBody(const std::string& body);
+    void validateVersionNotSuppoted();
+    void validateMethodNotAllowed();
 
     std::string            trimSpace(const std::string& string,
                                      const std::string  trim_char_set) const;

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -43,6 +43,10 @@ private:
     void parseFirstline(std::string line);
     void parseHeaderLine(std::string line);
     void parseBody(std::string body);
+
+    std::string trimSpace(const std::string& string,
+                          const std::string  trim_char_set);
+
     void throwErrorBadrequest(std::string err_message);
     void throwErrorMethodNotAllowed(std::string err_message);
     void throwErrorVersionNotSupported(std::string err_message);
@@ -50,12 +54,10 @@ private:
     void varidateMethod(std::string& method);
     void varidateRequestTarget(std::string request_target);
     void varidateHTTPVersion(std::string version);
-    bool isdigit(std::string str);
+    void varidateToken(std::string token);
 
-    bool        isLastLine(std::string& str);
-    bool        isToken(std::string str);
-    std::string trimSpace(const std::string& string,
-                          const std::string  trim_char_set);
+    bool isLastLine(std::string& str);
+    bool isdigit(std::string str);
 
     bool isSupportedMethod();
     bool isSupportedVersion();

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -20,7 +20,14 @@ public:
     // 対応するメソッド一覧。仮でここで宣言
     static std::set<std::string> methods;
 
+    // 改行コード
     static const std::string crlf;
+
+    // ステータス
+    static const int status_ok                    = 200;
+    static const int status_bad_request           = 400;
+    static const int status_method_not_allowed    = 405;
+    static const int status_version_not_supported = 505;
 
 private:
     std::string                        request_message_;
@@ -37,6 +44,8 @@ private:
     void parseHeaderLine(std::string line);
     void parseBody(std::string body);
     void throwErrorBadrequest(std::string err_message);
+    void throwErrorMethodNotAllowed(std::string err_message);
+    void throwErrorVersionNotSupported(std::string err_message);
 
     void varidateMethod(std::string& method);
     void varidateRequestTarget(std::string request_target);

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -15,7 +15,8 @@ public:
     int                                GetStatus();
     std::map<std::string, std::string> GetHeaders();
     std::string                        GetHeaderValue(std::string key);
-    void                               SetURI(std::string uri);
+
+    void SetURI(std::string uri);
 
     // 対応するメソッド一覧。仮でここで宣言
     static std::set<std::string> methods;
@@ -23,7 +24,7 @@ public:
     // 改行コード
     static const std::string crlf;
 
-    // ステータス
+    // ステータスコード
     static const int status_ok                    = 200;
     static const int status_bad_request           = 400;
     static const int status_method_not_allowed    = 405;
@@ -55,6 +56,7 @@ private:
     void varidateRequestTarget(std::string request_target);
     void varidateHTTPVersion(std::string version);
     void varidateToken(std::string token);
+    void varidateBody(std::string body);
 
     bool isLastLine(std::string& str);
     bool isdigit(std::string str);

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -9,12 +9,12 @@ public:
     HTTPRequest(const std::string& row);
     HTTPRequest(std::string method, std::string uri);
     ~HTTPRequest();
-    std::string&                       GetMethod();
-    std::string&                       GetRequestTarget();
-    std::string&                       GetVersion();
-    int                                GetStatus();
-    std::map<std::string, std::string> GetHeaders();
-    std::string                        GetHeaderValue(std::string key);
+    const std::string&                        GetMethod() const;
+    std::string                               GetRequestTarget() const;
+    const std::string&                        GetVersion() const;
+    int                                       GetStatus() const;
+    const std::map<std::string, std::string>& GetHeaders() const;
+    const std::string GetHeaderValue(std::string key) const;
 
     void SetURI(std::string uri);
 
@@ -36,34 +36,33 @@ private:
     std::string                        request_target_;
     std::string                        HTTPVersion_;
     std::string                        body_;
-    std::string                        row_;
+    const std::string                  row_;
     std::map<std::string, std::string> headers_;
     int                                status_;
 
     void parse();
-    void parseFirstline(std::string line);
+    void parseFirstline(const std::string& line);
     void parseHeaderLines(std::string& str);
-    void parseHeaderLine(std::string line);
-    void parseBody(std::string body);
+    void parseHeaderLine(const std::string& line);
+    void parseBody(std::string& body);
 
-    void throwErrorBadrequest(std::string err_message);
-    void throwErrorMethodNotAllowed(std::string err_message);
-    void throwErrorVersionNotSupported(std::string err_message);
+    void throwErrorBadrequest(const std::string err_message);
+    void throwErrorMethodNotAllowed(const std::string err_message);
+    void throwErrorVersionNotSupported(const std::string err_message);
 
-    void varidateMethod(std::string& method);
-    void varidateRequestTarget(std::string request_target);
-    void varidateHTTPVersion(std::string version);
-    void varidateToken(std::string token);
-    void varidateBody(std::string body);
+    void varidateMethod(const std::string& method);
+    void varidateRequestTarget(const std::string& request_target);
+    void varidateHTTPVersion(const std::string& version);
+    void varidateToken(const std::string& token);
+    void varidateBody(const std::string& body);
     void varidateVersionNotSuppoted();
     void varidateMethodNotAllowed();
 
     std::string            trimSpace(const std::string& string,
-                                     const std::string  trim_char_set);
-    std::string::size_type mustFindCRLF(std::string& str);
-    bool                   isLastLine(std::string& str);
-    bool                   isdigit(std::string& str);
-    bool                   hostExists();
+                                     const std::string  trim_char_set) const;
+    std::string::size_type mustFindCRLF(const std::string& str);
+    bool                   isdigit(const std::string& str) const;
+    bool                   hostExists() const;
 };
 
 #endif

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -22,7 +22,8 @@ public:
     static std::set<std::string> methods;
 
     // 改行コード
-    static const std::string crlf;
+    static const std::string            crlf;
+    static const std::string::size_type crlf_size;
 
     // ステータスコード
     static const int status_ok                    = 200;

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -38,6 +38,7 @@ private:
     void parseHeaderLine(std::string line);
     void parseBody(std::string body);
     bool isLastLine(std::string& str);
+    bool isToken(std::string str);
     void throwErrorBadrequest(std::string err_message);
 };
 

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -26,7 +26,7 @@ private:
     std::string                        request_message_;
     std::string                        method_;
     std::string                        request_target_;
-    std::string                        version_;
+    std::string                        HTTPVersion_;
     std::string                        body_;
     std::string                        row_;
     std::map<std::string, std::string> headers_;
@@ -39,7 +39,9 @@ private:
     void throwErrorBadrequest(std::string err_message);
 
     void varidateMethod(std::string& method);
-    void varidateRequestTarget(std::string& request_target);
+    void varidateRequestTarget(std::string request_target);
+    void varidateHTTPVersion(std::string version);
+    bool isdigit(std::string str);
 
     bool        isLastLine(std::string& str);
     bool        isToken(std::string str);

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -37,9 +37,12 @@ private:
     void parseFirstline(std::string line);
     void parseHeaderLine(std::string line);
     void parseBody(std::string body);
-    bool isLastLine(std::string& str);
-    bool isToken(std::string str);
     void throwErrorBadrequest(std::string err_message);
+
+    bool        isLastLine(std::string& str);
+    bool        isToken(std::string str);
+    std::string trimSpace(const std::string& string,
+                          const std::string  trim_char_set);
 };
 
 #endif

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -42,14 +42,9 @@ private:
 
     void parse();
     void parseFirstline(std::string line);
-    void parseHeaderLines(std::string&           str,
-                          std::string::size_type line_end_pos);
+    void parseHeaderLines(std::string& str);
     void parseHeaderLine(std::string line);
     void parseBody(std::string body);
-
-    std::string            trimSpace(const std::string& string,
-                                     const std::string  trim_char_set);
-    std::string::size_type mustFindCRLF(std::string& str);
 
     void throwErrorBadrequest(std::string err_message);
     void throwErrorMethodNotAllowed(std::string err_message);
@@ -63,9 +58,12 @@ private:
     void varidateVersionNotSuppoted();
     void varidateMethodNotAllowed();
 
-    bool isLastLine(std::string& str);
-    bool isdigit(std::string str);
-    bool hostExists();
+    std::string            trimSpace(const std::string& string,
+                                     const std::string  trim_char_set);
+    std::string::size_type mustFindCRLF(std::string& str);
+    bool                   isLastLine(std::string& str);
+    bool                   isdigit(std::string& str);
+    bool                   hostExists();
 };
 
 #endif

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -11,7 +11,7 @@ public:
     HTTPRequest(std::string method, std::string uri);
     ~HTTPRequest();
     std::string&                       GetMethod();
-    std::string&                       GetURI();
+    std::string&                       GetRequestTarget();
     std::string&                       GetVersion();
     int                                GetStatus();
     std::map<std::string, std::string> GetHeaders();
@@ -26,7 +26,7 @@ public:
 private:
     std::string                        request_message_;
     std::string                        method_;
-    std::string                        uri_;
+    std::string                        request_target_;
     std::string                        version_;
     std::string                        body_;
     std::string                        row_;
@@ -39,10 +39,17 @@ private:
     void parseBody(std::string body);
     void throwErrorBadrequest(std::string err_message);
 
+    void varidateMethod(std::string& method);
+    void varidateRequestTarget(std::string& request_target);
+
     bool        isLastLine(std::string& str);
     bool        isToken(std::string str);
     std::string trimSpace(const std::string& string,
                           const std::string  trim_char_set);
+
+    bool isSupportedMethod();
+    bool isSupportedVersion();
+    bool hostExists();
 };
 
 #endif

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -42,6 +42,8 @@ private:
 
     void parse();
     void parseFirstline(std::string line);
+    void parseHeaderLines(std::string&           str,
+                          std::string::size_type line_end_pos);
     void parseHeaderLine(std::string line);
     void parseBody(std::string body);
 

--- a/src/socket/StreamSocket.cpp
+++ b/src/socket/StreamSocket.cpp
@@ -65,12 +65,12 @@ void StreamSocket::parseRequest() {
     req_    = parser_->Parse(std::string(buf_));
 
     if (req_->GetMethod() == "GET") {
-        if (req_->GetURI() == "/") {
+        if (req_->GetRequestTarget() == "/") {
             req_->SetURI(std::string("/index.html"));
         }
 
         // uri で指定されたファイルを読み取る
-        std::ifstream ifs(req_->GetURI().erase(0, 1));
+        std::ifstream ifs(req_->GetRequestTarget().erase(0, 1));
         std::string   tmp, file_cotent;
         if (ifs.fail()) {
             // err

--- a/test/request.cpp
+++ b/test/request.cpp
@@ -107,6 +107,18 @@ TEST(HTTPRequest, SpecifyTarget) {
 
 // ERROR CASE
 // expect status 400
+TEST(HTTPRequest, EmptyMethod) {
+    testcase t = { "/ HTTP/1.1\r\n\r\n", 400, "", "", "", "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, EmptyRequestTarget) {
+    testcase t = { "GET HTTP/1.1\r\n\r\n", 400, "", "", "", "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
 TEST(HTTPRequest, LowercaseMethod) {
     testcase t = { "get / HTTP/1.1\r\n\r\n", 400, "", "", "", "" };
     testRequest(&t);
@@ -193,6 +205,13 @@ TEST(HTTPRequest, ValueContainLF) {
 TEST(HTTPRequest, KeyIncludeSpace) {
     testcase t = { "GET / HTTP/1.1\r\nHost : localhost\r\n\r\n", 400, "", "",
                    "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, EmptyKey) {
+    testcase t = { "GET / HTTP/1.1\r\nHost: localhost\r\n:hoge\r\n\r\n", 400,
+                   "", "", "" };
     testRequest(&t);
     printMessageIfFailed(t.message, testing::Test::HasFailure());
 }

--- a/test/request.cpp
+++ b/test/request.cpp
@@ -40,7 +40,7 @@ void testRequest(testcase* test) {
 
 // expect status 200
 TEST(HTTPRequest, Simple) {
-    testcase t = { "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
+    testcase t = { "GET / HTTP/1.1\r\nHost: localhost\r\nAccept: */*\r\n\r\n",
                    200,
                    "GET",
                    "index.html",
@@ -108,16 +108,20 @@ TEST(HTTPRequest, SpecifyTarget) {
 // ERROR CASE
 // expect status 400
 TEST(HTTPRequest, EmptyMethod) {
-    testcase t = { "/ HTTP/1.1\r\n\r\n", 400, "", "", "", "" };
+    testcase t = {
+        "/ HTTP/1.1\r\nHost: localhost\r\n\r\n", 400, "", "", "", ""
+    };
     testRequest(&t);
     printMessageIfFailed(t.message, testing::Test::HasFailure());
 }
 
-TEST(HTTPRequest, EmptyRequestTarget) {
-    testcase t = { "GET HTTP/1.1\r\n\r\n", 400, "", "", "", "" };
-    testRequest(&t);
-    printMessageIfFailed(t.message, testing::Test::HasFailure());
-}
+/* TEST(HTTPRequest, EmptyRequestTarget) { */
+/*     testcase t = { */
+/*         "GET HTTP/1.1\r\nHost: localhost\r\n\r\n", 400, "", "", "", "" */
+/*     }; */
+/*     testRequest(&t); */
+/*     printMessageIfFailed(t.message, testing::Test::HasFailure()); */
+/* } */
 
 TEST(HTTPRequest, MissingEmptyLine) {
     testcase t = { "GET HTTP/1.1\r\nHost: localhost\r\n", 400, "", "", "", "" };

--- a/test/request.cpp
+++ b/test/request.cpp
@@ -77,11 +77,13 @@ TEST(HTTPRequest, LowercaseMethod) {
     printMessageIfFailed(t.message, testing::Test::HasFailure());
 }
 
-/* TEST(HTTPRequest, NoHost) { */
-/*     testcase t = { "GET / HTTP/1.1\r\n\r\n", 400, "", "", "", "" }; */
-/*     testRequest(&t); */
-/*     printMessageIfFailed(t.message, testing::Test::HasFailure()); */
-/* } */
+TEST(HTTPRequest, NoHost) {
+    testcase t = {
+        "GET / HTTP/1.1\r\n\r\n", 400, "GET", "index.html", "HTTP/1.1", ""
+    };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
 
 TEST(HTTPRequest, VersionNotExistName) {
     testcase t = { "GET / /1.1\r\nHost: localhost\r\n\r\n", 400, "", "", "" };

--- a/test/request.cpp
+++ b/test/request.cpp
@@ -85,6 +85,7 @@ TEST(HTTPRequest, NoHost) {
     printMessageIfFailed(t.message, testing::Test::HasFailure());
 }
 
+// HTTP Version Error
 TEST(HTTPRequest, VersionNotExistName) {
     testcase t = { "GET / /1.1\r\nHost: localhost\r\n\r\n", 400, "", "", "" };
     testRequest(&t);
@@ -138,22 +139,28 @@ TEST(HTTPRequest, VersionNotExistdot) {
     printMessageIfFailed(t.message, testing::Test::HasFailure());
 }
 
+TEST(HTTPRequest, KeyIncludeSpace) {}
+
 // expect other status code
-/* TEST(HTTPRequest, UnsupportedMethod) { */
-/*     testcase t = { */
-/*         "HOGE / HTTP/1.1\r\nHost: localhost\r\n\r\n", 405, "", "", "", */
-/*     }; */
-/*     testRequest(&t); */
-/*     printMessageIfFailed(t.message, testing::Test::HasFailure()); */
-/* } */
+TEST(HTTPRequest, UnsupportedMethod) {
+    testcase t = { "HOGE / HTTP/1.1\r\nHost: localhost\r\n\r\n",
+                   405,
+                   "HOGE",
+                   "index.html",
+                   "HTTP/1.1",
+                   "localhost" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
 
-/* TEST(HTTPRequest, VersionNotSupported) { */
-/*     testcase t = { "GET / HTTP/3.0\r\nHost: localhost\r\n\r\n", 505, "", "",
- */
-/*                    "" }; */
-/*     testRequest(&t); */
-/*     printMessageIfFailed(t.message, testing::Test::HasFailure()); */
-/* } */
-
-/* TEST(HTTPRequest, KeyIncludeSpace) {} */
+TEST(HTTPRequest, VersionNotSupported) {
+    testcase t = { "GET / HTTP/3.0\r\nHost: localhost\r\n\r\n",
+                   505,
+                   "GET",
+                   "index.html",
+                   "HTTP/3.0",
+                   "localhost" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
 

--- a/test/request.cpp
+++ b/test/request.cpp
@@ -47,6 +47,39 @@ TEST(HTTPRequest, Simple) {
     printMessageIfFailed(t.message, testing::Test::HasFailure());
 }
 
+TEST(HTTPRequest, LowercaseHost) {
+    testcase t = { "GET / HTTP/1.1\r\nhost: localhost\r\n\r\n",
+                   200,
+                   "GET",
+                   "index.html",
+                   "HTTP/1.1",
+                   "localhost" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, SpaceBeforeValue) {
+    testcase t = { "GET / HTTP/1.1\r\nHost:     localhost\r\n\r\n",
+                   200,
+                   "GET",
+                   "index.html",
+                   "HTTP/1.1",
+                   "localhost" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, SpaceAfterValue) {
+    testcase t = { "GET / HTTP/1.1\r\nHost:localhost   \r\n\r\n",
+                   200,
+                   "GET",
+                   "index.html",
+                   "HTTP/1.1",
+                   "localhost" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
 TEST(HTTPRequest, NotSpecifyVersion) {
     testcase t = { "GET /\r\nHost: localhost\r\n\r\n",
                    200,
@@ -73,14 +106,6 @@ TEST(HTTPRequest, SpecifyTarget) {
 // expect status 400
 TEST(HTTPRequest, LowercaseMethod) {
     testcase t = { "get / HTTP/1.1\r\n\r\n", 400, "", "", "", "" };
-    testRequest(&t);
-    printMessageIfFailed(t.message, testing::Test::HasFailure());
-}
-
-TEST(HTTPRequest, NoHost) {
-    testcase t = {
-        "GET / HTTP/1.1\r\n\r\n", 400, "GET", "index.html", "HTTP/1.1", ""
-    };
     testRequest(&t);
     printMessageIfFailed(t.message, testing::Test::HasFailure());
 }
@@ -135,6 +160,29 @@ TEST(HTTPRequest, VersionNotExistSlash) {
 
 TEST(HTTPRequest, VersionNotExistdot) {
     testcase t = { "GET / HTTP/1\r\nHost: localhost\r\n\r\n", 400, "", "", "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+// 2行目以降のヘッダーエラー
+TEST(HTTPRequest, NoHost) {
+    testcase t = {
+        "GET / HTTP/1.1\r\n\r\n", 400, "GET", "index.html", "HTTP/1.1", ""
+    };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, ValueContainCR) {
+    testcase t = { "GET / HTTP/1\r\nHost: local\rhost\r\n\r\n", 400, "", "",
+                   "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, ValueContainLF) {
+    testcase t = { "GET / HTTP/1\r\nHost: local\nhost\r\n\r\n", 400, "", "",
+                   "" };
     testRequest(&t);
     printMessageIfFailed(t.message, testing::Test::HasFailure());
 }

--- a/test/request.cpp
+++ b/test/request.cpp
@@ -30,11 +30,12 @@ void testRequest(testcase* test) {
 
     ASSERT_EQ(test->expect_status, req.GetStatus());
     EXPECT_EQ(test->exepct_method, req.GetMethod());
-    EXPECT_EQ(test->expect_uri, req.GetURI());
+    EXPECT_EQ(test->expect_uri, req.GetRequestTarget());
     EXPECT_EQ(test->expect_version, req.GetVersion());
     EXPECT_EQ(test->expect_host, req.GetHeaderValue("Host"));
 }
 
+// expect status 200
 TEST(HTTPRequest, Simple) {
     testcase t = { "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n",
                    200,
@@ -68,32 +69,89 @@ TEST(HTTPRequest, SpecifyTarget) {
     printMessageIfFailed(t.message, testing::Test::HasFailure());
 }
 
+// ERROR CASE
+// expect status 400
 TEST(HTTPRequest, LowercaseMethod) {
     testcase t = { "get / HTTP/1.1\r\n\r\n", 400, "", "", "", "" };
     testRequest(&t);
     printMessageIfFailed(t.message, testing::Test::HasFailure());
 }
 
-TEST(HTTPRequest, NoHost) {
-    testcase t = { "GET / HTTP/1.1\r\n\r\n", 400, "", "", "", "" };
+/* TEST(HTTPRequest, NoHost) { */
+/*     testcase t = { "GET / HTTP/1.1\r\n\r\n", 400, "", "", "", "" }; */
+/*     testRequest(&t); */
+/*     printMessageIfFailed(t.message, testing::Test::HasFailure()); */
+/* } */
+
+TEST(HTTPRequest, VersionNotExistName) {
+    testcase t = { "GET / /1.1\r\nHost: localhost\r\n\r\n", 400, "", "", "" };
     testRequest(&t);
     printMessageIfFailed(t.message, testing::Test::HasFailure());
 }
 
-TEST(HTTPRequest, UnsupportedMethod) {
-    testcase t = {
-        "HOGE / HTTP/1.1\r\nHost: localhost\r\n\r\n", 405, "", "", "",
-    };
-    testRequest(&t);
-    printMessageIfFailed(t.message, testing::Test::HasFailure());
-}
-
-TEST(HTTPRequest, VersionNotSupported) {
-    testcase t = { "GET / HTTP/3.0\r\nHost: localhost\r\n\r\n", 505, "", "",
+TEST(HTTPRequest, VersionLowerCase) {
+    testcase t = { "GET / http/1.1\r\nHost: localhost\r\n\r\n", 400, "", "",
                    "" };
     testRequest(&t);
     printMessageIfFailed(t.message, testing::Test::HasFailure());
 }
 
-TEST(HTTPRequest, KeyIncludeSpace) {}
+TEST(HTTPRequest, VersionMultipleDot) {
+    testcase t = { "GET / HTTP/1.1.1\r\nHost: localhost\r\n\r\n", 400, "", "",
+                   "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, VersionEndWithDot) {
+    testcase t = { "GET / HTTP/1.\r\nHost: localhost\r\n\r\n", 400, "", "",
+                   "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, VersionStartWithDot) {
+    testcase t = { "GET / HTTP/.1\r\nHost: localhost\r\n\r\n", 400, "", "",
+                   "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, VersionOnlyName) {
+    testcase t = { "GET / HTTP/\r\nHost: localhost\r\n\r\n", 400, "", "", "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, VersionNotExistSlash) {
+    testcase t = { "GET / HTTP1.1\r\nHost: localhost\r\n\r\n", 400, "", "",
+                   "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, VersionNotExistdot) {
+    testcase t = { "GET / HTTP/1\r\nHost: localhost\r\n\r\n", 400, "", "", "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+// expect other status code
+/* TEST(HTTPRequest, UnsupportedMethod) { */
+/*     testcase t = { */
+/*         "HOGE / HTTP/1.1\r\nHost: localhost\r\n\r\n", 405, "", "", "", */
+/*     }; */
+/*     testRequest(&t); */
+/*     printMessageIfFailed(t.message, testing::Test::HasFailure()); */
+/* } */
+
+/* TEST(HTTPRequest, VersionNotSupported) { */
+/*     testcase t = { "GET / HTTP/3.0\r\nHost: localhost\r\n\r\n", 505, "", "",
+ */
+/*                    "" }; */
+/*     testRequest(&t); */
+/*     printMessageIfFailed(t.message, testing::Test::HasFailure()); */
+/* } */
+
+/* TEST(HTTPRequest, KeyIncludeSpace) {} */
 

--- a/test/request.cpp
+++ b/test/request.cpp
@@ -119,8 +119,14 @@ TEST(HTTPRequest, EmptyRequestTarget) {
     printMessageIfFailed(t.message, testing::Test::HasFailure());
 }
 
-TEST(HTTPRequest, NotExistEmptyLine) {
-    testcase t = { "GET HTTP/1.1\r\n", 400, "", "", "", "" };
+TEST(HTTPRequest, MissingEmptyLine) {
+    testcase t = { "GET HTTP/1.1\r\nHost: localhost\r\n", 400, "", "", "", "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, MssingCRLF) {
+    testcase t = { "GET HTTP/1.1\r\nHost: localhost", 400, "", "", "", "" };
     testRequest(&t);
     printMessageIfFailed(t.message, testing::Test::HasFailure());
 }

--- a/test/request.cpp
+++ b/test/request.cpp
@@ -119,6 +119,18 @@ TEST(HTTPRequest, EmptyRequestTarget) {
     printMessageIfFailed(t.message, testing::Test::HasFailure());
 }
 
+TEST(HTTPRequest, NotExistEmptyLine) {
+    testcase t = { "GET HTTP/1.1\r\n", 400, "", "", "", "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
+TEST(HTTPRequest, 2EmptyLine) {
+    testcase t = { "GET HTTP/1.1\r\n\r\n\r\n", 400, "", "", "", "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
+
 TEST(HTTPRequest, LowercaseMethod) {
     testcase t = { "get / HTTP/1.1\r\n\r\n", 400, "", "", "", "" };
     testRequest(&t);

--- a/test/request.cpp
+++ b/test/request.cpp
@@ -29,6 +29,9 @@ void testRequest(testcase* test) {
     HTTPRequest req(test->message);
 
     ASSERT_EQ(test->expect_status, req.GetStatus());
+    if (req.GetStatus() != 200) {
+        return;
+    }
     EXPECT_EQ(test->exepct_method, req.GetMethod());
     EXPECT_EQ(test->expect_uri, req.GetRequestTarget());
     EXPECT_EQ(test->expect_version, req.GetVersion());
@@ -174,20 +177,25 @@ TEST(HTTPRequest, NoHost) {
 }
 
 TEST(HTTPRequest, ValueContainCR) {
-    testcase t = { "GET / HTTP/1\r\nHost: local\rhost\r\n\r\n", 400, "", "",
+    testcase t = { "GET / HTTP/1.1\r\nHost: local\rhost\r\n\r\n", 400, "", "",
                    "" };
     testRequest(&t);
     printMessageIfFailed(t.message, testing::Test::HasFailure());
 }
 
 TEST(HTTPRequest, ValueContainLF) {
-    testcase t = { "GET / HTTP/1\r\nHost: local\nhost\r\n\r\n", 400, "", "",
+    testcase t = { "GET / HTTP/1.1\r\nHost: local\nhost\r\n\r\n", 400, "", "",
                    "" };
     testRequest(&t);
     printMessageIfFailed(t.message, testing::Test::HasFailure());
 }
 
-TEST(HTTPRequest, KeyIncludeSpace) {}
+TEST(HTTPRequest, KeyIncludeSpace) {
+    testcase t = { "GET / HTTP/1.1\r\nHost : localhost\r\n\r\n", 400, "", "",
+                   "" };
+    testRequest(&t);
+    printMessageIfFailed(t.message, testing::Test::HasFailure());
+}
 
 // expect other status code
 TEST(HTTPRequest, UnsupportedMethod) {


### PR DESCRIPTION
## やったこと

- HTTPリクエストのパース、バリデート

## やらないこと

- StreamSocket::parseRequest()ではこのプリリクで使ってるコードは動いてないです。
- `request target` (GET / の "/"の部分)のバリデートはrfcに書いてあることがパッと分からなかったので一旦放置してます。
  - response作成と併せてやろうと思ってます。

## 動作確認

- google test作った
```
[==========] Running 27 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 27 tests from HTTPRequest
[ RUN      ] HTTPRequest.Simple
[       OK ] HTTPRequest.Simple (0 ms)
[ RUN      ] HTTPRequest.LowercaseHost
[       OK ] HTTPRequest.LowercaseHost (0 ms)
[ RUN      ] HTTPRequest.SpaceBeforeValue
[       OK ] HTTPRequest.SpaceBeforeValue (0 ms)
[ RUN      ] HTTPRequest.SpaceAfterValue
[       OK ] HTTPRequest.SpaceAfterValue (0 ms)
[ RUN      ] HTTPRequest.NotSpecifyVersion
[       OK ] HTTPRequest.NotSpecifyVersion (0 ms)
[ RUN      ] HTTPRequest.SpecifyTarget
[       OK ] HTTPRequest.SpecifyTarget (0 ms)
[ RUN      ] HTTPRequest.EmptyMethod
[       OK ] HTTPRequest.EmptyMethod (0 ms)
[ RUN      ] HTTPRequest.EmptyRequestTarget
[       OK ] HTTPRequest.EmptyRequestTarget (0 ms)
[ RUN      ] HTTPRequest.MissingEmptyLine
[       OK ] HTTPRequest.MissingEmptyLine (0 ms)
[ RUN      ] HTTPRequest.MssingCRLF
[       OK ] HTTPRequest.MssingCRLF (0 ms)
[ RUN      ] HTTPRequest.2EmptyLine
[       OK ] HTTPRequest.2EmptyLine (0 ms)
[ RUN      ] HTTPRequest.LowercaseMethod
[       OK ] HTTPRequest.LowercaseMethod (0 ms)
[ RUN      ] HTTPRequest.VersionNotExistName
[       OK ] HTTPRequest.VersionNotExistName (0 ms)
[ RUN      ] HTTPRequest.VersionLowerCase
[       OK ] HTTPRequest.VersionLowerCase (0 ms)
[ RUN      ] HTTPRequest.VersionMultipleDot
[       OK ] HTTPRequest.VersionMultipleDot (0 ms)
[ RUN      ] HTTPRequest.VersionEndWithDot
[       OK ] HTTPRequest.VersionEndWithDot (0 ms)
[ RUN      ] HTTPRequest.VersionStartWithDot
[       OK ] HTTPRequest.VersionStartWithDot (0 ms)
[ RUN      ] HTTPRequest.VersionOnlyName
[       OK ] HTTPRequest.VersionOnlyName (0 ms)
[ RUN      ] HTTPRequest.VersionNotExistSlash
[       OK ] HTTPRequest.VersionNotExistSlash (0 ms)
[ RUN      ] HTTPRequest.VersionNotExistdot
[       OK ] HTTPRequest.VersionNotExistdot (0 ms)
[ RUN      ] HTTPRequest.NoHost
[       OK ] HTTPRequest.NoHost (0 ms)
[ RUN      ] HTTPRequest.ValueContainCR
[       OK ] HTTPRequest.ValueContainCR (0 ms)
[ RUN      ] HTTPRequest.ValueContainLF
[       OK ] HTTPRequest.ValueContainLF (0 ms)
[ RUN      ] HTTPRequest.KeyIncludeSpace
[       OK ] HTTPRequest.KeyIncludeSpace (0 ms)
[ RUN      ] HTTPRequest.EmptyKey
[       OK ] HTTPRequest.EmptyKey (0 ms)
[ RUN      ] HTTPRequest.UnsupportedMethod
[       OK ] HTTPRequest.UnsupportedMethod (0 ms)
[ RUN      ] HTTPRequest.VersionNotSupported
[       OK ] HTTPRequest.VersionNotSupported (0 ms)
[----------] 27 tests from HTTPRequest (4 ms total)

[----------] Global test environment tear-down
[==========] 27 tests from 1 test suite ran. (4 ms total)
[  PASSED  ] 27 tests.

```

# その他
- コンストラクターで`parse()`を呼んでいるので、`parse()`から読んでもらえるといいかもです。

## issues

about : #24 