### PR TITLE
:up: StreamSocketにイベントを持たせる

### DIFF
--- a/src/event/EventActions.cpp
+++ b/src/event/EventActions.cpp
@@ -135,14 +135,26 @@ void EventActions::onEvent(std::vector<struct kevent> active_list,
             if (active_list[i].flags == EV_EOF) {
                 s_sock->OnDisConnect();
                 delete s_sock;
-            } else if (active_list[i].filter == EVFILT_READ) {
-                std::cout << "Recv REQUEST" << std::endl;
-                s_sock->OnRecv();
-            } else if (active_list[i].filter == EVFILT_WRITE) {
-                std::cout << "Send RESPONSE" << std::endl;
-                s_sock->OnSend();
-                delete s_sock;
+            } else {
+                handleStreamSocketEvent(s_sock);
             }
         }
+    }
+}
+
+void EventActions::handleStreamSocketEvent(StreamSocket* sock) {
+    switch (sock->GetEventType()) {
+    case StreamSocket::RECV_REQUEST:
+        std::cout << "Recv REQUEST" << std::endl;
+        sock->OnRecv();
+        break;
+
+    case StreamSocket::SEND_RESPONSE:
+        std::cout << "Send RESPONSE" << std::endl;
+        sock->OnSend();
+        delete sock;
+
+    default:
+        break;
     }
 }

--- a/src/event/EventActions.cpp
+++ b/src/event/EventActions.cpp
@@ -153,6 +153,7 @@ void EventActions::handleStreamSocketEvent(StreamSocket* sock) {
         std::cout << "Send RESPONSE" << std::endl;
         sock->OnSend();
         delete sock;
+        break;
 
     default:
         break;

--- a/src/event/EventActions.hpp
+++ b/src/event/EventActions.hpp
@@ -7,6 +7,7 @@
 #include "Socket.hpp"
 
 class Socket;
+class StreamSocket;
 class EventActions {
 public:
     EventActions();
@@ -28,6 +29,7 @@ public:
 
 private:
     void onEvent(std::vector<struct kevent> active_list, int event_size);
+    void handleStreamSocketEvent(StreamSocket* sock);
 
     int                        kqueue_fd_;
     std::vector<struct kevent> change_list_;

--- a/src/extended_c/ExecveArray.hpp
+++ b/src/extended_c/ExecveArray.hpp
@@ -10,8 +10,8 @@ public:
         initExecveArray(strs.begin(), strs.end());
     }
 
-    char* const* get() const { return ptrs_.data(); }
-    size_t       get_size() { return str_.size(); }
+    char* const* Get() const { return ptrs_.data(); }
+    size_t       GetSize() { return str_.size(); }
 
 private:
     ExecveArray() {}

--- a/src/socket/Socket.hpp
+++ b/src/socket/Socket.hpp
@@ -7,7 +7,7 @@
 class EventActions;
 class Socket {
 public:
-    enum SOCKET_TYPE {
+    enum SocketType {
         LISTENING,
         STREAM,
     };
@@ -16,8 +16,8 @@ public:
     Socket(int sock) : sock_fd_(sock) {}
     virtual ~Socket() {}
 
-    void        SetSocketType(SOCKET_TYPE type) { type_ = type; }
-    SOCKET_TYPE GetSocketType() { return type_; }
+    void       SetSocketType(SocketType type) { type_ = type; }
+    SocketType GetSocketType() { return type_; }
 
     void SetSocketFd(const int& sock) { sock_fd_ = sock; }
     int  GetSocketFd() { return sock_fd_; }
@@ -30,7 +30,7 @@ public:
 
 protected:
     int                sock_fd_;
-    SOCKET_TYPE        type_;
+    SocketType         type_;
     struct sockaddr_in addr_;
 
     EventActions* actions_;

--- a/src/socket/StreamSocket.cpp
+++ b/src/socket/StreamSocket.cpp
@@ -12,8 +12,8 @@
 #include <sstream>
 
 StreamSocket::StreamSocket()
-    : req_(HTTPRequest()), parser_(HTTPParser(req_)), res_(NULL), read_size_(0),
-      buf_size_(2048) {
+    : req_(HTTPRequest()), parser_(HTTPParser(req_)), res_(NULL),
+      event_type_(RECV_REQUEST), read_size_(0), buf_size_(2048) {
     SetSocketType(Socket::STREAM);
 }
 
@@ -35,6 +35,10 @@ StreamSocket::~StreamSocket() {
 
 HTTPRequest* StreamSocket::GetHTTPRequest() { return &req_; }
 
+const StreamSocket::EventType& StreamSocket::GetEventType() const {
+    return event_type_;
+}
+
 void StreamSocket::Recv() {
     if (actions_) {
         actions_->AddRecvEvent(this);
@@ -45,6 +49,7 @@ void StreamSocket::Send() {
     if (actions_) {
         actions_->AddSendEvent(this);
     }
+    setEventType(SEND_RESPONSE);
 }
 
 void StreamSocket::Close() {
@@ -113,4 +118,8 @@ void StreamSocket::OnDisConnect() {
     if (actions_) {
         actions_->DelEvent(this);
     }
+}
+
+void StreamSocket::setEventType(StreamSocket::EventType type) {
+    event_type_ = type;
 }

--- a/src/socket/StreamSocket.hpp
+++ b/src/socket/StreamSocket.hpp
@@ -12,10 +12,18 @@ class HTTPRequest;
 class HTTPResponse;
 class StreamSocket : public Socket {
 public:
+    enum EventType {
+        RECV_REQUEST,
+        SEND_RESPONSE,
+        WRITE_CGI,
+        READ_CGI,
+    };
+
     StreamSocket();
     virtual ~StreamSocket();
 
-    HTTPRequest* GetHTTPRequest();
+    HTTPRequest*     GetHTTPRequest();
+    const EventType& GetEventType() const;
 
     // Add event
     void Recv();
@@ -29,15 +37,17 @@ public:
 
 private:
     void parseRequest();
+    void setEventType(EventType type);
 
 private:
     HTTPRequest   req_;
     HTTPParser    parser_;
     HTTPResponse* res_;
 
-    int     read_size_;
-    ssize_t buf_size_;
-    char    buf_[2048];
+    EventType event_type_;
+    int       read_size_;
+    ssize_t   buf_size_;
+    char      buf_[2048];
 };
 
 #endif


### PR DESCRIPTION
今までソケットの状態でイベント(read可能かwrite可能のみ)を判定していたが、StreamSocket自体に持たせることでイベントの数を増やせた。

About: #44

## やったこと

StreamSocketにイベントを保持させる。
現段階で設定しているイベントの種類は以下です。
- リクエストの受け取り
- レスポンスの送信
- CGIの読み込み
- CGIへの書き込み

## やらないこと

- StreamSocketが持つ情報が多いですが、一旦このままで

## 動作確認

- 動作に問題はないが、リクエストを返した時点でソケットを解放しているので同一クライアントから複数回GETすることはできません。
```
☁  webserv [feature/event] ./webserv
Recv REQUEST
Recv REQUEST
Recv REQUEST
Send RESPONSE
<<message>>
HTTP/1.1 200 OK
Content-Length: 219

<!DOCTYPE html>
<html lang="ja">
        <head>
                <meta charset="UTF-8">
                <link rel="icon" href="data:image/x-icon;," type="image/x-icon">
                <title>INDEX.HTML</title>
        </head>
        <body>
                <h1>HELLO WORLD!</h1>
        </body>
</html>
```
```
// 別ターミナル
☁  webserv [feature/event] telnet localhost 5000
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
GET / HTTP/1.1
Host: localhost

HTTP/1.1 200 OK
Content-Length: 219

<!DOCTYPE html>
<html lang="ja">
        <head>
                <meta charset="UTF-8">
                <link rel="icon" href="data:image/x-icon;," type="image/x-icon">
                <title>INDEX.HTML</title>
        </head>
        <body>
                <h1>HELLO WORLD!</h1>
        </body>
</html>

// 二度目は動かない
GET / HTTP/1.1
Host: localhost

```

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

## issues

about : #44

close : #44 
