### PR TITLE
HTTPResponseクラス実装

### DIFF
--- a/src/response/HTTPResponse.cpp
+++ b/src/response/HTTPResponse.cpp
@@ -2,41 +2,73 @@
 #include "SysError.hpp"
 #include <cerrno>
 #include <iostream>
+#include <sstream>
 #include <sys/socket.h>
 #include <sys/types.h>
 
-HTTPResponse::HTTPResponse(int sock, int status_code, std::string header,
-                           std::string body)
-    : sock_(sock), status_code_(status_code), header_(header), body_(body) {}
+HTTPResponse::HTTPResponse() : status_code_(200) {
+    status_text[200] = "OK";
+    status_text[400] = "Bad Request";
+    status_text[404] = "Not Found";
+}
+
+HTTPResponse::HTTPResponse(int sock, int status_code, std::string body)
+    : sock_(sock), status_code_(status_code), body_(body) {}
 
 HTTPResponse::~HTTPResponse() {}
 
-void HTTPResponse::SetHeader(std::string key, std::string value) {
+void HTTPResponse::AppendHeader(std::string key, std::string value) {
     headers_.insert(std::make_pair(key, value));
 }
 
-void HTTPResponse::SetBody(std::string body) { body_ = body; }
+void HTTPResponse::SetBody(std::string body) {
+    std::ostringstream oss;
+    oss << body.size() << std::flush;
+    AppendHeader("Content-Length", oss.str());
+    body_ = body;
+}
+
+void HTTPResponse::SetVersion(std::string version) { HTTPVersion_ = version; }
+
+void HTTPResponse::SetStatus(int status) { status_code_ = status; }
 
 void HTTPResponse::Create() {
-    // 文字列で扱って大丈夫？バイナリの可能性は？
-    // TODO:レスポンスのサイズをつくる
+    std::ostringstream oss;
+    std::string        length;
+    oss << body_.size() << std::flush;
+    length = oss.str();
+    std::string size("Content-Length: " + length);
 
     if (status_code_ == 200) {
-        response_message_ =
-            "HTTP/1.1 200 OK\r\n" + header_ + "\r\n\r\n" + body_;
+        message_ = "HTTP/1.1 200 OK\r\n" + size + "\r\n\r\n" + body_;
     } else if (status_code_ == 404) {
-        response_message_ = "HTTP1.1 404 No Found\r\n" + header_ + "\r\n";
+        message_ = "HTTP/1.1 404 Not Found\r\n" + size + "\r\n";
     } else {
         std::cout << "Not support status" << status_code_ << std::endl;
     }
-    message_size_ = response_message_.size();
+
+    std::cout << "status: " << status_code_ << std::endl;
+    std::cout << "body: " << body_ << std::endl;
+}
+
+std::string HTTPResponse::ConvertToStr() {
+    std::stringstream ss;
+    ss << HTTPVersion_ << " " << status_code_ << " "
+       << status_text[status_code_] << "\r\n";
+
+    for (std::map<std::string, std::string>::iterator it = headers_.begin();
+         it != headers_.end(); it++) {
+        ss << it->first << ": " << it->second << "\r\n";
+    }
+    ss << "\r\n";
+    ss << body_;
+
+    return ss.str();
 }
 
 void HTTPResponse::SendMessage() {
-    std::cout << "<<message>>\n" << response_message_ << std::endl;
-    int ret = send(sock_, response_message_.c_str(), message_size_, 0);
+    int ret = send(sock_, message_.c_str(), message_.size(), 0);
     if (ret == -1) {
         throw SysError("send", errno);
-        // std::cout << "send error" << std::endl;
     }
 }

--- a/src/response/HTTPResponse.cpp
+++ b/src/response/HTTPResponse.cpp
@@ -6,11 +6,17 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 
-HTTPResponse::HTTPResponse() : status_code_(200) {
+std::map<int, std::string> make_status_text() {
+    std::map<int, std::string> status_text;
     status_text[200] = "OK";
     status_text[400] = "Bad Request";
     status_text[404] = "Not Found";
+    return status_text;
 }
+
+std::map<int, std::string> HTTPResponse::status_text = make_status_text();
+
+HTTPResponse::HTTPResponse() : status_code_(200) {}
 
 HTTPResponse::~HTTPResponse() {}
 

--- a/src/response/HTTPResponse.cpp
+++ b/src/response/HTTPResponse.cpp
@@ -28,6 +28,8 @@ void HTTPResponse::SetBody(std::string body) {
 
 void HTTPResponse::SetVersion(std::string version) { HTTPVersion_ = version; }
 
+void HTTPResponse::SetStatusCode(int status) { status_code_ = status; }
+
 std::string HTTPResponse::ConvertToStr() {
     std::stringstream ss;
     ss << HTTPVersion_ << " " << status_code_ << " "

--- a/src/response/HTTPResponse.cpp
+++ b/src/response/HTTPResponse.cpp
@@ -1,10 +1,5 @@
 #include "HTTPResponse.hpp"
-#include "SysError.hpp"
-#include <cerrno>
-#include <iostream>
 #include <sstream>
-#include <sys/socket.h>
-#include <sys/types.h>
 
 std::map<int, std::string> make_status_text() {
     std::map<int, std::string> status_text;

--- a/src/response/HTTPResponse.cpp
+++ b/src/response/HTTPResponse.cpp
@@ -15,6 +15,8 @@ void HTTPResponse::SetHeader(std::string key, std::string value) {
     headers_.insert(std::make_pair(key, value));
 }
 
+void HTTPResponse::SetBody(std::string body) { body_ = body; }
+
 void HTTPResponse::Create() {
     // 文字列で扱って大丈夫？バイナリの可能性は？
     // TODO:レスポンスのサイズをつくる

--- a/src/response/HTTPResponse.cpp
+++ b/src/response/HTTPResponse.cpp
@@ -12,9 +12,6 @@ HTTPResponse::HTTPResponse() : status_code_(200) {
     status_text[404] = "Not Found";
 }
 
-HTTPResponse::HTTPResponse(int sock, int status_code, std::string body)
-    : sock_(sock), status_code_(status_code), body_(body) {}
-
 HTTPResponse::~HTTPResponse() {}
 
 void HTTPResponse::AppendHeader(std::string key, std::string value) {

--- a/src/response/HTTPResponse.cpp
+++ b/src/response/HTTPResponse.cpp
@@ -11,16 +11,8 @@ HTTPResponse::HTTPResponse(int sock, int status_code, std::string header,
 
 HTTPResponse::~HTTPResponse() {}
 
-HTTPResponse::HTTPResponse(const HTTPResponse& other) { *this = other; }
-
-HTTPResponse& HTTPResponse::operator=(const HTTPResponse& other) {
-    if (this != &other) {
-        sock_        = other.sock_;
-        status_code_ = other.status_code_;
-        header_      = other.header_;
-        body_        = other.body_;
-    }
-    return *this;
+void HTTPResponse::SetHeader(std::string key, std::string value) {
+    headers_.insert(std::make_pair(key, value));
 }
 
 void HTTPResponse::Create() {

--- a/src/response/HTTPResponse.cpp
+++ b/src/response/HTTPResponse.cpp
@@ -30,12 +30,13 @@ void HTTPResponse::SetVersion(std::string version) { HTTPVersion_ = version; }
 
 void HTTPResponse::SetStatusCode(int status) { status_code_ = status; }
 
-std::string HTTPResponse::ConvertToStr() {
+std::string HTTPResponse::ConvertToStr() const {
     std::stringstream ss;
     ss << HTTPVersion_ << " " << status_code_ << " "
        << status_text[status_code_] << "\r\n";
 
-    for (std::map<std::string, std::string>::iterator it = headers_.begin();
+    for (std::map<std::string, std::string>::const_iterator it =
+             headers_.begin();
          it != headers_.end(); it++) {
         ss << it->first << ": " << it->second << "\r\n";
     }

--- a/src/response/HTTPResponse.cpp
+++ b/src/response/HTTPResponse.cpp
@@ -30,27 +30,6 @@ void HTTPResponse::SetBody(std::string body) {
 
 void HTTPResponse::SetVersion(std::string version) { HTTPVersion_ = version; }
 
-void HTTPResponse::SetStatus(int status) { status_code_ = status; }
-
-void HTTPResponse::Create() {
-    std::ostringstream oss;
-    std::string        length;
-    oss << body_.size() << std::flush;
-    length = oss.str();
-    std::string size("Content-Length: " + length);
-
-    if (status_code_ == 200) {
-        message_ = "HTTP/1.1 200 OK\r\n" + size + "\r\n\r\n" + body_;
-    } else if (status_code_ == 404) {
-        message_ = "HTTP/1.1 404 Not Found\r\n" + size + "\r\n";
-    } else {
-        std::cout << "Not support status" << status_code_ << std::endl;
-    }
-
-    std::cout << "status: " << status_code_ << std::endl;
-    std::cout << "body: " << body_ << std::endl;
-}
-
 std::string HTTPResponse::ConvertToStr() {
     std::stringstream ss;
     ss << HTTPVersion_ << " " << status_code_ << " "
@@ -64,11 +43,4 @@ std::string HTTPResponse::ConvertToStr() {
     ss << body_;
 
     return ss.str();
-}
-
-void HTTPResponse::SendMessage() {
-    int ret = send(sock_, message_.c_str(), message_.size(), 0);
-    if (ret == -1) {
-        throw SysError("send", errno);
-    }
 }

--- a/src/response/HTTPResponse.cpp
+++ b/src/response/HTTPResponse.cpp
@@ -19,12 +19,7 @@ void HTTPResponse::AppendHeader(std::string key, std::string value) {
     headers_.insert(std::make_pair(key, value));
 }
 
-void HTTPResponse::SetBody(std::string body) {
-    std::ostringstream oss;
-    oss << body.size() << std::flush;
-    AppendHeader("Content-Length", oss.str());
-    body_ = body;
-}
+void HTTPResponse::SetBody(std::string body) { body_ = body; }
 
 void HTTPResponse::SetVersion(std::string version) { HTTPVersion_ = version; }
 

--- a/src/response/HTTPResponse.hpp
+++ b/src/response/HTTPResponse.hpp
@@ -1,5 +1,6 @@
 #ifndef HTTPRESPONSE_HPP
 #define HTTPRESPONSE_HPP
+#include <map>
 #include <string>
 
 class HTTPResponse {
@@ -7,18 +8,20 @@ public:
     HTTPResponse(int sock, int status_code, std::string header,
                  std::string body);
     ~HTTPResponse();
-    HTTPResponse(const HTTPResponse& other);
-    HTTPResponse& operator=(const HTTPResponse& other);
-    void          Create();
-    void          SendMessage();
+
+    void SetHeader(std::string key, std::string value);
+
+    void Create();
+    void SendMessage();
 
 private:
-    int         sock_;
-    int         status_code_;
-    std::string header_;
-    std::string body_;
-    std::string response_message_;
-    std::size_t message_size_;
+    int                                sock_;
+    int                                status_code_;
+    std::map<std::string, std::string> headers_;
+    std::string                        header_;
+    std::string                        body_;
+    std::string                        response_message_;
+    std::size_t                        message_size_;
 };
 
 #endif

--- a/src/response/HTTPResponse.hpp
+++ b/src/response/HTTPResponse.hpp
@@ -12,6 +12,7 @@ public:
 
     void SetBody(std::string body);
     void SetVersion(std::string version);
+    void SetStatusCode(int status);
 
     std::string ConvertToStr();
 

--- a/src/response/HTTPResponse.hpp
+++ b/src/response/HTTPResponse.hpp
@@ -14,7 +14,7 @@ public:
     void SetVersion(std::string version);
     void SetStatusCode(int status);
 
-    std::string ConvertToStr();
+    std::string ConvertToStr() const;
 
 private:
     static std::map<int, std::string> status_text;

--- a/src/response/HTTPResponse.hpp
+++ b/src/response/HTTPResponse.hpp
@@ -14,11 +14,6 @@ public:
     void SetBody(std::string body);
     void SetVersion(std::string version);
 
-    // いらないかも
-    void SetStatus(int status);
-
-    void                       Create();
-    void                       SendMessage();
     std::string                ConvertToStr();
     std::map<int, std::string> status_text;
 

--- a/src/response/HTTPResponse.hpp
+++ b/src/response/HTTPResponse.hpp
@@ -10,6 +10,7 @@ public:
     ~HTTPResponse();
 
     void SetHeader(std::string key, std::string value);
+    void SetBody(std::string body);
 
     void Create();
     void SendMessage();

--- a/src/response/HTTPResponse.hpp
+++ b/src/response/HTTPResponse.hpp
@@ -13,13 +13,14 @@ public:
     void SetBody(std::string body);
     void SetVersion(std::string version);
 
-    std::string                ConvertToStr();
-    std::map<int, std::string> status_text;
+    std::string ConvertToStr();
 
 private:
+    static std::map<int, std::string> status_text;
+
+    std::string                        HTTPVersion_;
     int                                status_code_;
     std::map<std::string, std::string> headers_;
-    std::string                        HTTPVersion_;
     std::string                        body_;
 
     std::string message_;

--- a/src/response/HTTPResponse.hpp
+++ b/src/response/HTTPResponse.hpp
@@ -5,24 +5,31 @@
 
 class HTTPResponse {
 public:
-    HTTPResponse(int sock, int status_code, std::string header,
-                 std::string body);
+    HTTPResponse();
+    HTTPResponse(int sock, int status_code, std::string body);
     ~HTTPResponse();
 
-    void SetHeader(std::string key, std::string value);
-    void SetBody(std::string body);
+    void AppendHeader(std::string key, std::string value);
 
-    void Create();
-    void SendMessage();
+    void SetBody(std::string body);
+    void SetVersion(std::string version);
+
+    // いらないかも
+    void SetStatus(int status);
+
+    void                       Create();
+    void                       SendMessage();
+    std::string                ConvertToStr();
+    std::map<int, std::string> status_text;
 
 private:
     int                                sock_;
     int                                status_code_;
     std::map<std::string, std::string> headers_;
-    std::string                        header_;
+    std::string                        HTTPVersion_;
     std::string                        body_;
-    std::string                        response_message_;
-    std::size_t                        message_size_;
+
+    std::string message_;
 };
 
 #endif

--- a/src/response/HTTPResponse.hpp
+++ b/src/response/HTTPResponse.hpp
@@ -6,7 +6,6 @@
 class HTTPResponse {
 public:
     HTTPResponse();
-    HTTPResponse(int sock, int status_code, std::string body);
     ~HTTPResponse();
 
     void AppendHeader(std::string key, std::string value);
@@ -18,7 +17,6 @@ public:
     std::map<int, std::string> status_text;
 
 private:
-    int                                sock_;
     int                                status_code_;
     std::map<std::string, std::string> headers_;
     std::string                        HTTPVersion_;

--- a/src/socket/StreamSocket.cpp
+++ b/src/socket/StreamSocket.cpp
@@ -75,6 +75,9 @@ void StreamSocket::OnRecv() {
             file_content += tmp + "\n";
         }
 
+        std::stringstream ss;
+        ss << file_content.size() << std::flush;
+        resp_.AppendHeader("Content-Length", ss.str());
         resp_.SetBody(file_content);
         resp_.AppendHeader("Server", "Webserv/1.0.0");
         resp_.SetVersion(req_.GetVersion());

--- a/src/socket/StreamSocket.hpp
+++ b/src/socket/StreamSocket.hpp
@@ -40,9 +40,9 @@ private:
     void setEventType(EventType type);
 
 private:
-    HTTPRequest   req_;
-    HTTPParser    parser_;
-    HTTPResponse* res_;
+    HTTPRequest  req_;
+    HTTPParser   parser_;
+    HTTPResponse resp_;
 
     EventType event_type_;
     int       read_size_;

--- a/test/gtest.cpp
+++ b/test/gtest.cpp
@@ -7,5 +7,6 @@
 
 /* Include all tests files */
 
-#include "httpparser.cpp"
 #include "execve_array_test.cpp"
+#include "httpparser.cpp"
+#include "response.cpp"

--- a/test/response.cpp
+++ b/test/response.cpp
@@ -1,0 +1,44 @@
+#include "HTTPResponse.hpp"
+#include <gtest/gtest.h>
+
+using namespace std;
+
+TEST(HTTPResponse, SetVersion) {
+    HTTPResponse resp;
+    resp.SetVersion("HTTP/1.1");
+
+    string expect = "HTTP/1.1 200 OK\r\n\r\n";
+    string actual = resp.ConvertToStr();
+    EXPECT_EQ(expect, actual);
+}
+
+TEST(HTTPResponse, SetBody) {
+    HTTPResponse resp;
+    resp.SetVersion("HTTP/1.1");
+    resp.SetBody("hoge");
+
+    string expect = "HTTP/1.1 200 OK\r\n\r\nhoge";
+    string actual = resp.ConvertToStr();
+    EXPECT_EQ(expect, actual);
+}
+
+TEST(HTTPResponse, AppendHeader) {
+    HTTPResponse resp;
+    resp.SetVersion("HTTP/1.1");
+    resp.SetBody("hoge");
+    resp.AppendHeader("Content-Length", "4");
+
+    string expect = "HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nhoge";
+    string actual = resp.ConvertToStr();
+    EXPECT_EQ(expect, actual);
+}
+
+TEST(HTTPResponse, BadRequest) {
+    HTTPResponse resp;
+    resp.SetVersion("HTTP/1.1");
+    resp.SetStatusCode(400);
+
+    string expect = "HTTP/1.1 400 Bad Request\r\n\r\n";
+    string actual = resp.ConvertToStr();
+    EXPECT_EQ(expect, actual);
+}


### PR DESCRIPTION
## やったこと

- HTTPResponseクラスの雛形作成
  - クラスの役割はレスポンスの情報を持ち、それを送りやすいように１つの文字列に変換すること(`ConvertToStr()`)に限定しました。
  - 元のコードはクラス内で`send()`も行っていたのをクラスの外(StreamSocket)に出しました。
  - レスポンスの情報は5つです。
    - HTTPバージョン
    - ステータスコード (200)
    - ステータステキスト (OK)
    - ヘッダー
    - ボディ

- StreamSocketクラス内でHTTPResponseクラスはポインタで持たないようにした。


## やらないこと

- GET等のメソッドに応じてレスポンスを作成する処理
  - レスポンスを作成するクラスにHTTPResponseクラスの参照を渡すイメージです。
- 改行コードやステータスコードなどの定数をどこかで定義すること
  - あとでやりたいです。

## 動作確認

- Google Test
```
[----------] 4 tests from HTTPResponse
[ RUN      ] HTTPResponse.SetVersion
[       OK ] HTTPResponse.SetVersion (0 ms)
[ RUN      ] HTTPResponse.SetBody
[       OK ] HTTPResponse.SetBody (0 ms)
[ RUN      ] HTTPResponse.AppendHeader
[       OK ] HTTPResponse.AppendHeader (0 ms)
[ RUN      ] HTTPResponse.BadRequest
[       OK ] HTTPResponse.BadRequest (0 ms)
[----------] 4 tests from HTTPResponse (0 ms total)

```

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

## issues

about : #45 

close #45
