### PR TITLE
:bug: bodyのパースで無限ループするのを修正

### DIFF
--- a/src/request/parse.cpp
+++ b/src/request/parse.cpp
@@ -255,6 +255,7 @@ void update_state(State& state, const std::string new_buf) {
                     parse_header_line(req, line);
                 }
                 break;
+
             case BODY:
                 if (!needs_parse_body(req.GetMethod())) {
                     phase = DONE;
@@ -263,7 +264,7 @@ void update_state(State& state, const std::string new_buf) {
                 might_set_body(
                     state, buf,
                     str_to_ulong(req.GetHeaderValue("Content-length")));
-                break;
+                return;
 
             case DONE:
                 return;


### PR DESCRIPTION
## やったこと
bodyのパースの場合はループさせる必要がないので`break`を`return`にした

## 動作確認

- telnetで送信した場合でも無限ループしないことを確認した

