### PR TITLE
:up: HTTPResponseのコンストラクタでdefault_versionで初期化

### DIFF
--- a/src/response/HTTPResponse.cpp
+++ b/src/response/HTTPResponse.cpp
@@ -1,17 +1,21 @@
 #include "HTTPResponse.hpp"
+#include "HTTPStatus.hpp"
 #include <sstream>
+
+const std::string HTTPResponse::default_version = "HTTP/1.1";
 
 std::map<int, std::string> make_status_text() {
     std::map<int, std::string> status_text;
-    status_text[200] = "OK";
-    status_text[400] = "Bad Request";
-    status_text[404] = "Not Found";
+    status_text[status::ok]          = "OK";
+    status_text[status::bad_request] = "Bad Request";
+    status_text[status::not_found]   = "Not Found";
     return status_text;
 }
 
 std::map<int, std::string> HTTPResponse::status_text = make_status_text();
 
-HTTPResponse::HTTPResponse() : status_code_(200) {}
+HTTPResponse::HTTPResponse()
+    : HTTPVersion_(default_version), status_code_(status::ok) {}
 
 HTTPResponse::~HTTPResponse() {}
 

--- a/src/response/HTTPResponse.hpp
+++ b/src/response/HTTPResponse.hpp
@@ -16,6 +16,8 @@ public:
 
     std::string ConvertToStr() const;
 
+    static const std::string default_version;
+
 private:
     static std::map<int, std::string> status_text;
 

--- a/src/response/HTTPStatus.hpp
+++ b/src/response/HTTPStatus.hpp
@@ -4,6 +4,7 @@
 namespace status {
 const int ok                            = 200;
 const int bad_request                   = 400;
+const int not_found                     = 404;
 const int method_not_allowed            = 405;
 const int validate_version_not_suppoted = 505;
 } // namespace status

--- a/test/response.cpp
+++ b/test/response.cpp
@@ -14,7 +14,6 @@ TEST(HTTPResponse, SetVersion) {
 
 TEST(HTTPResponse, SetBody) {
     HTTPResponse resp;
-    resp.SetVersion("HTTP/1.1");
     resp.SetBody("hoge");
 
     string expect = "HTTP/1.1 200 OK\r\n\r\nhoge";
@@ -24,7 +23,6 @@ TEST(HTTPResponse, SetBody) {
 
 TEST(HTTPResponse, AppendHeader) {
     HTTPResponse resp;
-    resp.SetVersion("HTTP/1.1");
     resp.SetBody("hoge");
     resp.AppendHeader("Content-Length", "4");
 
@@ -35,7 +33,6 @@ TEST(HTTPResponse, AppendHeader) {
 
 TEST(HTTPResponse, BadRequest) {
     HTTPResponse resp;
-    resp.SetVersion("HTTP/1.1");
     resp.SetStatusCode(400);
 
     string expect = "HTTP/1.1 400 Bad Request\r\n\r\n";


### PR DESCRIPTION
## やったこと

- HTTPのバージョンは1.1しか対応する予定がないので、HTTPResponseクラスのコンストラクタでデフォルトバージョンとしてセットするようにした。
- HTTPStatus.hpp内の定義を使うようにした。

## 動作確認

- responseのgoogleテストでSetVersionを呼ばなくてもバージョンがセットされているのを確認した。
```c++
TEST(HTTPResponse, SetBody) {
    HTTPResponse resp;
    resp.SetBody("hoge");

    string expect = "HTTP/1.1 200 OK\r\n\r\nhoge";
    string actual = resp.ConvertToStr();
    EXPECT_EQ(expect, actual);
}
```

## その他

- HTTPStatusにステータスコード定義してあるので使ってください。適宜追加していく感じで。

