### PR TITLE
Feature/cgi post

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ TESTSRCS  := CGI.cpp \
 			ReadFile.cpp \
 			RecvRequest.cpp \
 			SendResponse.cpp \
+			WriteCGI.cpp \
 			EventExecutor.cpp \
 			EventRegister.cpp \
 			ListeningSocket.cpp \

--- a/docs/cgi/stdin.py
+++ b/docs/cgi/stdin.py
@@ -1,5 +1,9 @@
 import sys
 import os
 
-input = sys.stdin.read(int('5'))
+print('call stdin.py')
+print('CONTENT_LENGTH: ', os.environ['CONTENT_LENGTH'])
+print('------CONTENT START-------')
+input = sys.stdin.read(int(os.environ['CONTENT_LENGTH']))
 print(input)
+print('------CONTENT   END-------')

--- a/docs/cgi/stdin.py
+++ b/docs/cgi/stdin.py
@@ -1,0 +1,5 @@
+import sys
+import os
+
+input = sys.stdin.read(int('5'))
+print(input)

--- a/src/cgi/CGI.cpp
+++ b/src/cgi/CGI.cpp
@@ -23,6 +23,7 @@ CGI::CGI(const HTTPRequest req)
     : req_(req), extension_(std::string()), local_path_(std::string()) {
     // pipeの初期化
     std::fill_n(pipe_for_cgi_write_, 2, -1);
+    std::fill_n(pipe_for_cgi_read_, 2, -1);
 }
 
 CGI::~CGI() {}
@@ -51,6 +52,8 @@ void CGI::Run() {
 
 int CGI::FdForReadFromCGI() { return pipe_for_cgi_write_[0]; }
 
+int CGI::FdForWriteToCGI() { return pipe_for_cgi_read_[1]; }
+
 void CGI::cgiParseRequest() {
     std::string target = req_.GetRequestTarget();
 
@@ -65,6 +68,7 @@ void CGI::cgiParseRequest() {
     }
 
     local_path_ = target;
+    method_     = req_.GetMethod();
 }
 
 std::string CGI::makeExecutableBinary() {
@@ -91,7 +95,7 @@ std::vector<std::string> CGI::makeEnvs() {
 
     // 環境変数を順に決定
     env_map["AUTH_TYPE"]         = "";
-    env_map["CONTENT_LENGTH"]    = "";
+    env_map["CONTENT_LENGTH"]    = "5";
     env_map["CONTENT_TYPE"]      = "";
     env_map["GATEWAY_INTERFACE"] = "";
     env_map["PATH_INFO"]         = "";
@@ -120,6 +124,15 @@ std::vector<std::string> CGI::makeEnvs() {
 }
 
 void CGI::createPipe() {
+    if (method_ == "POST") {
+        if (pipe(pipe_for_cgi_read_) < 0) {
+            throw SysError("pipe", errno);
+        }
+        int flags = fcntl(pipe_for_cgi_write_[0], F_GETFD);
+        fcntl(pipe_for_cgi_write_[0], F_SETFD, flags | FD_CLOEXEC);
+        flags = fcntl(pipe_for_cgi_write_[0], F_GETFL);
+        fcntl(pipe_for_cgi_write_[0], F_SETFL, flags | O_NONBLOCK);
+    }
     if (pipe(pipe_for_cgi_write_) < 0) {
         throw SysError("pipe", errno);
     }
@@ -135,6 +148,7 @@ void CGI::cgiFork() {
     if (pid < 0) {
         throw SysError("fork", errno);
     } else if (pid == 0) {
+        std::cout << "IN CHILD" << std::endl;
         childOperatePipe();
         execute();
     } else {
@@ -143,6 +157,13 @@ void CGI::cgiFork() {
 }
 
 void CGI::childOperatePipe() {
+    // stdin
+    close(pipe_for_cgi_read_[1]);
+    close(STDIN_FILENO);
+    dup2(pipe_for_cgi_read_[0], STDIN_FILENO);
+    close(pipe_for_cgi_read_[0]);
+
+    // stdout
     close(pipe_for_cgi_write_[0]);
     close(STDOUT_FILENO);
     dup2(pipe_for_cgi_write_[1], STDOUT_FILENO);
@@ -158,6 +179,8 @@ void CGI::execute() {
 }
 
 void CGI::parentOperatePipe() {
+    close(pipe_for_cgi_read_[0]);
+
     close(pipe_for_cgi_write_[1]);
     fcntl(pipe_for_cgi_write_[0], F_SETFL, O_NONBLOCK);
 }

--- a/src/cgi/CGI.cpp
+++ b/src/cgi/CGI.cpp
@@ -5,6 +5,7 @@
 #include <fcntl.h>
 #include <map>
 #include <signal.h> // signal()
+#include <sstream>
 #include <string>
 #include <unistd.h>
 #include <vector>
@@ -50,6 +51,13 @@ void CGI::Run() {
     cgiFork();
 }
 
+void CGI::ShutDown() {
+    if (req_.GetMethod() == "POST") {
+        close(pipe_for_cgi_read_[1]);
+    }
+    close(pipe_for_cgi_write_[0]);
+}
+
 int CGI::FdForReadFromCGI() { return pipe_for_cgi_write_[0]; }
 
 int CGI::FdForWriteToCGI() { return pipe_for_cgi_read_[1]; }
@@ -92,10 +100,13 @@ std::vector<std::string> CGI::makeArgs() {
 
 std::vector<std::string> CGI::makeEnvs() {
     std::map<std::string, std::string> env_map;
+    std::ostringstream                 oss;
 
     // 環境変数を順に決定
-    env_map["AUTH_TYPE"]         = "";
-    env_map["CONTENT_LENGTH"]    = "5";
+    env_map["AUTH_TYPE"] = "";
+    oss << req_.GetBody().size() << std::flush;
+    env_map["CONTENT_LENGTH"] = oss.str();
+    oss.str("");
     env_map["CONTENT_TYPE"]      = "";
     env_map["GATEWAY_INTERFACE"] = "";
     env_map["PATH_INFO"]         = "";
@@ -128,16 +139,18 @@ void CGI::createPipe() {
         if (pipe(pipe_for_cgi_read_) < 0) {
             throw SysError("pipe", errno);
         }
-        int flags = fcntl(pipe_for_cgi_write_[0], F_GETFD);
-        fcntl(pipe_for_cgi_write_[0], F_SETFD, flags | FD_CLOEXEC);
-        flags = fcntl(pipe_for_cgi_write_[0], F_GETFL);
-        fcntl(pipe_for_cgi_write_[0], F_SETFL, flags | O_NONBLOCK);
+        int flags = fcntl(pipe_for_cgi_read_[0], F_GETFD);
+        fcntl(pipe_for_cgi_read_[0], F_SETFD, flags | FD_CLOEXEC);
+        flags = fcntl(pipe_for_cgi_read_[0], F_GETFL);
+        fcntl(pipe_for_cgi_read_[0], F_SETFL, flags | O_NONBLOCK);
     }
     if (pipe(pipe_for_cgi_write_) < 0) {
         throw SysError("pipe", errno);
     }
     int flags = fcntl(pipe_for_cgi_write_[1], F_GETFD);
     fcntl(pipe_for_cgi_write_[1], F_SETFD, flags | FD_CLOEXEC);
+    flags = fcntl(pipe_for_cgi_write_[0], F_GETFL);
+    fcntl(pipe_for_cgi_write_[0], F_SETFL, flags | O_NONBLOCK);
 }
 
 void CGI::cgiFork() {
@@ -148,7 +161,6 @@ void CGI::cgiFork() {
     if (pid < 0) {
         throw SysError("fork", errno);
     } else if (pid == 0) {
-        std::cout << "IN CHILD" << std::endl;
         childOperatePipe();
         execute();
     } else {
@@ -158,10 +170,12 @@ void CGI::cgiFork() {
 
 void CGI::childOperatePipe() {
     // stdin
-    close(pipe_for_cgi_read_[1]);
-    close(STDIN_FILENO);
-    dup2(pipe_for_cgi_read_[0], STDIN_FILENO);
-    close(pipe_for_cgi_read_[0]);
+    if (req_.GetMethod() == "POST") {
+        close(pipe_for_cgi_read_[1]);
+        close(STDIN_FILENO);
+        dup2(pipe_for_cgi_read_[0], STDIN_FILENO);
+        close(pipe_for_cgi_read_[0]);
+    }
 
     // stdout
     close(pipe_for_cgi_write_[0]);
@@ -179,10 +193,11 @@ void CGI::execute() {
 }
 
 void CGI::parentOperatePipe() {
-    close(pipe_for_cgi_read_[0]);
+    if (req_.GetMethod() == "POST") {
+        close(pipe_for_cgi_read_[0]);
+    }
 
     close(pipe_for_cgi_write_[1]);
-    fcntl(pipe_for_cgi_write_[0], F_SETFL, O_NONBLOCK);
 }
 
 std::map<std::string, std::string> CGI::setBinaries() {

--- a/src/cgi/CGI.hpp
+++ b/src/cgi/CGI.hpp
@@ -16,6 +16,7 @@ public:
     void        Run();
 
     int FdForReadFromCGI();
+    int FdForWriteToCGI();
 
 private:
     CGI();
@@ -35,11 +36,13 @@ private:
 
     std::string              extension_;
     std::string              local_path_;
+    std::string              method_;
     std::string              exec_binary_;
     std::vector<std::string> args_;
     std::vector<std::string> envs_;
 
     int pipe_for_cgi_write_[2];
+    int pipe_for_cgi_read_[2];
 
     static const std::map<std::string, std::string> binaries;
     static const std::map<std::string, std::string> commands;

--- a/src/cgi/CGI.hpp
+++ b/src/cgi/CGI.hpp
@@ -14,6 +14,7 @@ public:
 
     static bool IsCGI(const std::string& target);
     void        Run();
+    void        ShutDown();
 
     int FdForReadFromCGI();
     int FdForWriteToCGI();

--- a/src/event/mode/ReadCGI.cpp
+++ b/src/event/mode/ReadCGI.cpp
@@ -12,6 +12,8 @@
 #include "StreamSocket.hpp"
 #include "SysError.hpp"
 
+const std::size_t ReadCGI::buf_size = 2048;
+
 ReadCGI::ReadCGI(int fd_read_from_cgi, StreamSocket stream, HTTPRequest req)
     : IOEvent(fd_read_from_cgi, READ_CGI), stream_(stream), req_(req),
       is_finish_(false), resp_(HTTPResponse()) {}
@@ -25,17 +27,15 @@ ReadCGI::~ReadCGI() {
 }
 
 void ReadCGI::Run() {
-    std::cout << "Read From CGI Start" << std::endl;
-    char buf[2048];
+    char buf[buf_size];
     int  fd_from_cgi = polled_fd_;
 
-    int read_size = read(fd_from_cgi, buf, 2048 - 1);
+    int read_size = read(fd_from_cgi, buf, buf_size);
     if (read_size < 0) {
         throw SysError("read", errno);
     } else if (read_size == 0) {
         is_finish_ = true;
     } else {
-        buf[read_size] = '\0';
         cgi_output_.append(buf, read_size);
     }
 }

--- a/src/event/mode/ReadCGI.hpp
+++ b/src/event/mode/ReadCGI.hpp
@@ -11,7 +11,7 @@
 class ReadCGI : public IOEvent {
 public:
     ReadCGI(int fd_read_from_cgi, StreamSocket stream, HTTPRequest req);
-    ~ReadCGI();
+    virtual ~ReadCGI();
 
     virtual void     Run();
     virtual IOEvent* RegisterNext();

--- a/src/event/mode/ReadCGI.hpp
+++ b/src/event/mode/ReadCGI.hpp
@@ -18,6 +18,8 @@ public:
     virtual void     Unregister();
     virtual IOEvent* RegisterNext();
 
+    static const std::size_t buf_size;
+
 private:
     ReadCGI();
 

--- a/src/event/mode/RecvRequest.cpp
+++ b/src/event/mode/RecvRequest.cpp
@@ -9,6 +9,7 @@
 #include "ReadFile.hpp"
 #include "SendResponse.hpp"
 #include "StreamSocket.hpp"
+#include "WriteCGI.hpp"
 
 #include <iostream>
 
@@ -56,6 +57,17 @@ IOEvent* RecvRequest::prepareResponse() {
         EventRegister::Instance().DelReadEvent(this);
         EventRegister::Instance().AddReadEvent(new_event);
         return new_event;
+    } else if (req_.GetMethod() == "POST") {
+        if (CGI::IsCGI(req_.GetRequestTarget())) {
+            std::cout << "CGI POST" << std::endl;
+            CGI cgi(req_);
+            cgi.Run();
+            std::cout << "CGI POST" << std::endl;
+            new_event = new WriteCGI(cgi, stream_, req_);
+            EventRegister::Instance().DelReadEvent(this);
+            EventRegister::Instance().AddWriteEvent(new_event);
+            return new_event;
+        }
     }
     return NULL;
 }

--- a/src/event/mode/RecvRequest.cpp
+++ b/src/event/mode/RecvRequest.cpp
@@ -66,13 +66,11 @@ IOEvent* RecvRequest::prepareResponse() {
         return new_event;
     } else if (req_.GetMethod() == "POST") {
         if (CGI::IsCGI(req_.GetRequestTarget())) {
-            std::cout << "CGI POST" << std::endl;
             CGI cgi(req_);
             cgi.Run();
-            std::cout << "CGI POST" << std::endl;
             new_event = new WriteCGI(cgi, stream_, req_);
-            EventRegister::Instance().DelReadEvent(this);
-            EventRegister::Instance().AddWriteEvent(new_event);
+            this->Unregister();
+            new_event->Register();
             return new_event;
         }
     }

--- a/src/event/mode/WriteCGI.cpp
+++ b/src/event/mode/WriteCGI.cpp
@@ -1,0 +1,49 @@
+#include "WriteCGI.hpp"
+
+#include <cerrno>
+#include <string>
+#include <unistd.h>
+
+#include "CGI.hpp"
+#include "EventRegister.hpp"
+#include "HTTPRequest.hpp"
+#include "IOEvent.hpp"
+#include "ReadCGI.hpp"
+#include "StreamSocket.hpp"
+#include "SysError.hpp"
+
+#include <iostream>
+
+WriteCGI::WriteCGI(CGI cgi, StreamSocket stream, HTTPRequest req)
+    : IOEvent(cgi.FdForWriteToCGI(), WRITE_CGI), cgi_(cgi), stream_(stream),
+      req_(req) {}
+
+WriteCGI::~WriteCGI() {
+    int fd = polled_fd_;
+    if (fd != -1) {
+        close(fd);
+        polled_fd_ = -1;
+    }
+}
+
+void WriteCGI::Run() {
+    std::cout << "Write CGI Run" << std::endl;
+    int         fd_write_to_cgi = polled_fd_;
+    std::string content         = "12345";
+    int write_size = write(fd_write_to_cgi, content.c_str(), content.size());
+    if (write_size < 0 || static_cast<size_t>(write_size) != content.size()) {
+        throw SysError("write", errno);
+    }
+}
+
+IOEvent* WriteCGI::RegisterNext() {
+    Unregister();
+
+    IOEvent* read_cgi = new ReadCGI(cgi_.FdForReadFromCGI(), stream_, req_);
+    EventRegister::Instance().AddReadEvent(read_cgi);
+    return read_cgi;
+}
+
+void WriteCGI::Unregister() {
+    EventRegister::Instance().DelWriteEvent(this);
+}

--- a/src/event/mode/WriteCGI.cpp
+++ b/src/event/mode/WriteCGI.cpp
@@ -27,27 +27,23 @@ WriteCGI::~WriteCGI() {
 }
 
 void WriteCGI::Run() {
-    std::cout << "Write CGI Run" << std::endl;
-    int         fd_write_to_cgi = polled_fd_;
-    std::string content         = "12345";
-    int write_size = write(fd_write_to_cgi, content.c_str(), content.size());
-    if (write_size < 0 || static_cast<size_t>(write_size) != content.size()) {
+    int fd_write_to_cgi = polled_fd_;
+    int write_size =
+        write(fd_write_to_cgi, req_.GetBody().c_str(), req_.GetBody().size());
+    if (write_size < 0 ||
+        static_cast<size_t>(write_size) != req_.GetBody().size()) {
         throw SysError("write", errno);
     }
 }
 
-void WriteCGI::Register() {
-    EventRegister::Instance().AddWriteEvent(this);
-}
+void WriteCGI::Register() { EventRegister::Instance().AddWriteEvent(this); }
 
-void WriteCGI::Unregister() {
-    EventRegister::Instance().DelWriteEvent(this);
-}
+void WriteCGI::Unregister() { EventRegister::Instance().DelWriteEvent(this); }
 
 IOEvent* WriteCGI::RegisterNext() {
     Unregister();
 
     IOEvent* read_cgi = new ReadCGI(cgi_.FdForReadFromCGI(), stream_, req_);
-    EventRegister::Instance().AddReadEvent(read_cgi);
+    read_cgi->Register();
     return read_cgi;
 }

--- a/src/event/mode/WriteCGI.hpp
+++ b/src/event/mode/WriteCGI.hpp
@@ -1,0 +1,28 @@
+#ifndef WRITE_CGI_HPP
+#define WRITE_CGI_HPP
+
+#include "CGI.hpp"
+#include "HTTPRequest.hpp"
+#include "IOEvent.hpp"
+#include "StreamSocket.hpp"
+
+class WriteCGI : public IOEvent {
+public:
+    WriteCGI(CGI cgi, StreamSocket stream, HTTPRequest req);
+    virtual ~WriteCGI();
+
+    virtual void     Run();
+    virtual IOEvent* RegisterNext();
+
+    virtual void Unregister();
+
+private:
+    WriteCGI();
+
+private:
+    CGI          cgi_;
+    StreamSocket stream_;
+    HTTPRequest  req_;
+};
+
+#endif

--- a/src/request/HTTPParser.cpp
+++ b/src/request/HTTPParser.cpp
@@ -119,7 +119,7 @@ void HTTPParser::validateVersionNotSuppoted() {
 }
 
 void HTTPParser::validateMethodNotAllowed() {
-    if (req_.GetMethod() != "GET") {
+    if (req_.GetMethod() != "POST") {
         throwErrorMethodNotAllowed();
     }
 }


### PR DESCRIPTION
## やったこと

- CGIのPOST機能の追加
serverがrequestのbodyをcgiへ書き込み、cgiは標準入力から受け取る。
cgiは結果を標準出力しserverはpipeを通して受け取る

```mermaid
flowchart TD
    A[CGI start] --- B([execveに必要な実行ファイル&&引数&&環境変数を用意])
    B --> C[pipe]
    C --> D[fork]
    D -- 子プロセス ---- E{{pipe0を標準入力へ}}
    subgraph child
    E --> G{{標準入力から受け取る}}
    G --> H{{標準出力をpipe1へ}}
    H --> I[execve]
    end
    D -- 親プロセス --> F{{bodyをpipe1へ書き込む}}
    subgraph parent
    F --> J{{pipe0から読み込み}}
    end
    F -.- G
    I -.- J
    J --> K[CGI end]
```

## やらないこと

- encode decode周りはまだ何もしていません。

## 動作確認
`make`した後、`webserv`起動
```bash
$ make
$  ./webserv

```
別のターミナルで`telnet localhost 5000`した後
```
POST /docs/cgi/stdin.py HTTP/1.1
Host: localhost
Content-Length: 5

12345
```
を入力する。

結果
```
// another terminal
$ telnet localhost 5000
POST /docs/cgi/stdin.py HTTP/1.1
Host: localhost
Content-Length: 5

12345
HTTP/1.1 200 OK
Content-Length: 95
Server: Webserv/1.0.0

call stdin.py
CONTENT_LENGTH:  7
------CONTENT START-------
12345

------CONTENT   END-------
```
## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

## issues

about : #55 

close: #55
