### PR TITLE
HTTPリクエストのParse中のエラーハンドリング

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ tester
 #others
 compile_commands.json
 *.dSYM
+.cache/*

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ TESTSRCS  := CGI.cpp \
 			ReadFile.cpp \
 			RecvRequest.cpp \
 			SendResponse.cpp \
+			SendError.cpp \
 			WriteCGI.cpp \
 			EventExecutor.cpp \
 			EventRegister.cpp \

--- a/src/event/EventExecutor.cpp
+++ b/src/event/EventExecutor.cpp
@@ -9,6 +9,7 @@
 
 #include "EventRegister.hpp"
 #include "HTTPResponse.hpp"
+#include "HTTPStatus.hpp"
 #include "IOEvent.hpp"
 #include "SendError.hpp"
 #include "StreamSocket.hpp"
@@ -69,7 +70,7 @@ void EventExecutor::onEvent(std::vector<struct kevent> event_vec,
             doEvent(event);
             // 次のイベントを決定する
             next_event = event;
-        } catch (std::pair<StreamSocket, HTTPResponse>& err) {
+        } catch (std::pair<StreamSocket, status::code>& err) {
             next_event = new SendError(err.first, err.second);
             event->Unregister();
             delete event;

--- a/src/event/EventExecutor.cpp
+++ b/src/event/EventExecutor.cpp
@@ -68,7 +68,6 @@ void EventExecutor::onEvent(std::vector<struct kevent> event_vec,
         try {
             // イベント実行
             doEvent(event);
-            // 次のイベントを決定する
             next_event = event;
         } catch (std::pair<StreamSocket, status::code>& err) {
             next_event = new SendError(err.first, err.second);

--- a/src/event/mode/RecvRequest.cpp
+++ b/src/event/mode/RecvRequest.cpp
@@ -7,6 +7,7 @@
 #include "CGI.hpp"
 #include "EventRegister.hpp"
 #include "HTTPResponse.hpp"
+#include "HTTPStatus.hpp"
 #include "ReadCGI.hpp"
 #include "ReadFile.hpp"
 #include "SendResponse.hpp"
@@ -34,9 +35,13 @@ void RecvRequest::Run() {
 
     try {
         HTTPParser::update_state(state_, std::string(buf, recv_size));
-    } catch (HTTPResponse& resp) {
-        throw std::make_pair(stream_, resp);
+    } catch (status::code code) {
+        std::cout << "catch code" << std::endl;
+        throw std::make_pair(stream_, code);
     }
+    /* } catch (HTTPResponse& resp) { */
+    /*     throw std::make_pair(stream_, resp); */
+    /* } */
 }
 
 void RecvRequest::Register() { EventRegister::Instance().AddReadEvent(this); }

--- a/src/event/mode/RecvRequest.cpp
+++ b/src/event/mode/RecvRequest.cpp
@@ -36,9 +36,10 @@ void RecvRequest::Run() {
     try {
         HTTPParser::update_state(state_, std::string(buf, recv_size));
     } catch (status::code code) {
-        std::cout << "catch code" << std::endl;
+        // parseエラーが起きた場合
         // TODO: pairを投げる関数作る
         throw std::make_pair(stream_, code);
+        // EventExecutor::onEventでcatch
     }
 }
 

--- a/src/event/mode/RecvRequest.cpp
+++ b/src/event/mode/RecvRequest.cpp
@@ -35,10 +35,7 @@ void RecvRequest::Run() {
     try {
         HTTPParser::update_state(state_, std::string(buf, recv_size));
     } catch (HTTPResponse& resp) {
-        std::cout << "catch response" << std::endl;
-        std::pair<StreamSocket, HTTPResponse> pair =
-            std::make_pair(stream_, resp);
-        throw pair;
+        throw std::make_pair(stream_, resp);
     }
 }
 

--- a/src/event/mode/RecvRequest.cpp
+++ b/src/event/mode/RecvRequest.cpp
@@ -37,11 +37,9 @@ void RecvRequest::Run() {
         HTTPParser::update_state(state_, std::string(buf, recv_size));
     } catch (status::code code) {
         std::cout << "catch code" << std::endl;
+        // TODO: pairを投げる関数作る
         throw std::make_pair(stream_, code);
     }
-    /* } catch (HTTPResponse& resp) { */
-    /*     throw std::make_pair(stream_, resp); */
-    /* } */
 }
 
 void RecvRequest::Register() { EventRegister::Instance().AddReadEvent(this); }

--- a/src/event/mode/SendError.cpp
+++ b/src/event/mode/SendError.cpp
@@ -1,0 +1,29 @@
+#include "SendError.hpp"
+#include "DefaultErrorPage.hpp"
+#include "EventRegister.hpp"
+#include "SendResponse.hpp"
+#include <sstream>
+
+SendError::SendError(StreamSocket& stream, HTTPResponse& resp)
+    : stream_(stream), resp_(resp) {}
+
+SendError::~SendError() {}
+
+void SendError::Run() {}
+
+void SendError::Register() {}
+
+void SendError::Unregister() {}
+
+IOEvent* SendError::RegisterNext() {
+    // config見てデフォルトエラーページの項目あるか確認
+    // あったらReadFileを作成、登録
+    resp_.SetBody(DefaultErrorPage::bad_request);
+    std::stringstream ss;
+    ss << DefaultErrorPage::bad_request.size() << std::flush;
+    resp_.AppendHeader("Content-Length", ss.str());
+
+    IOEvent* send_response = new SendResponse(stream_, resp_.ConvertToStr());
+    EventRegister::Instance().AddWriteEvent(send_response);
+    return send_response;
+}

--- a/src/event/mode/SendError.cpp
+++ b/src/event/mode/SendError.cpp
@@ -21,17 +21,22 @@ IOEvent* SendError::RegisterNext() {
     HTTPResponse resp;
     resp.SetStatusCode(status_code_);
 
+    std::stringstream body_size;
     switch (status_code_) {
     case status::bad_request:
         resp.SetBody(DefaultErrorPage::bad_request);
+        body_size << DefaultErrorPage::bad_request.size() << std::flush;
         break;
     case status::method_not_allowed:
+        resp.SetBody(DefaultErrorPage::method_not_allowed);
+        body_size << DefaultErrorPage::method_not_allowed.size() << std::flush;
         break;
+    case status::version_not_suppoted:
+        resp.SetBody(DefaultErrorPage::version_not_suppoted);
+        body_size << DefaultErrorPage::version_not_suppoted.size()
+                  << std::flush;
     }
-
-    std::stringstream ss;
-    ss << DefaultErrorPage::bad_request.size() << std::flush;
-    resp.AppendHeader("Content-Length", ss.str());
+    resp.AppendHeader("Content-Length", body_size.str());
 
     IOEvent* send_response = new SendResponse(stream_, resp.ConvertToStr());
     EventRegister::Instance().AddWriteEvent(send_response);

--- a/src/event/mode/SendError.hpp
+++ b/src/event/mode/SendError.hpp
@@ -16,7 +16,7 @@ public:
     virtual IOEvent* RegisterNext();
 
 private:
-    StreamSocket stream_;
-    status::code status_code_;
+    StreamSocket& stream_;
+    status::code  status_code_;
 };
 #endif // SEND_ERROR_HPP

--- a/src/event/mode/SendError.hpp
+++ b/src/event/mode/SendError.hpp
@@ -1,12 +1,13 @@
 #ifndef SEND_ERROR_HPP
 #define SEND_ERROR_HPP
 #include "HTTPResponse.hpp"
+#include "HTTPStatus.hpp"
 #include "IOEvent.hpp"
 #include "StreamSocket.hpp"
 
 class SendError : public IOEvent {
 public:
-    SendError(StreamSocket& stream, HTTPResponse& resp);
+    SendError(StreamSocket& stream, status::code);
     virtual ~SendError();
 
     virtual void     Run();
@@ -15,7 +16,7 @@ public:
     virtual IOEvent* RegisterNext();
 
 private:
-    StreamSocket  stream_;
-    HTTPResponse& resp_;
+    StreamSocket stream_;
+    status::code status_code_;
 };
 #endif // SEND_ERROR_HPP

--- a/src/event/mode/SendError.hpp
+++ b/src/event/mode/SendError.hpp
@@ -1,0 +1,21 @@
+#ifndef SEND_ERROR_HPP
+#define SEND_ERROR_HPP
+#include "HTTPResponse.hpp"
+#include "IOEvent.hpp"
+#include "StreamSocket.hpp"
+
+class SendError : public IOEvent {
+public:
+    SendError(StreamSocket& stream, HTTPResponse& resp);
+    virtual ~SendError();
+
+    virtual void     Run();
+    virtual void     Register();
+    virtual void     Unregister();
+    virtual IOEvent* RegisterNext();
+
+private:
+    StreamSocket  stream_;
+    HTTPResponse& resp_;
+};
+#endif // SEND_ERROR_HPP

--- a/src/request/parse.cpp
+++ b/src/request/parse.cpp
@@ -15,14 +15,18 @@ void throw_error_badrequest(const std::string err_message = "bad request") {
 
 void throw_error_method_not_allowed(
     const std::string err_message = "method not allowed") {
-    /* req.SetStatus(HTTPRequest::status_method_not_allowed); */
-    throw std::runtime_error(err_message);
+    std::cout << err_message << std::endl;
+    HTTPResponse resp;
+    resp.SetStatusCode(status::method_not_allowed);
+    throw resp;
 }
 
 void throw_error_version_not_supported(
     const std::string err_message = "version not supported") {
-    /* req.SetStatus(HTTPRequest::status_version_not_supported); */
-    throw std::runtime_error(err_message);
+    std::cout << err_message << std::endl;
+    HTTPResponse resp;
+    resp.SetStatusCode(status::validate_version_not_suppoted);
+    throw resp;
 }
 
 // token  = 1*tchar

--- a/src/request/parse.cpp
+++ b/src/request/parse.cpp
@@ -7,20 +7,20 @@
 
 namespace {
 void throw_error_badrequest(const std::string err_message = "bad request") {
-    std::cout << err_message << std::endl;
+    std::cerr << err_message << std::endl;
     throw status::bad_request;
 }
 
 void throw_error_method_not_allowed(
     const std::string err_message = "method not allowed") {
-    std::cout << err_message << std::endl;
+    std::cerr << err_message << std::endl;
     throw status::method_not_allowed;
 }
 
 void throw_error_version_not_supported(
     const std::string err_message = "version not supported") {
-    std::cout << err_message << std::endl;
-    throw status::validate_version_not_suppoted;
+    std::cerr << err_message << std::endl;
+    throw status::version_not_suppoted;
 }
 
 // token  = 1*tchar

--- a/src/request/parse.cpp
+++ b/src/request/parse.cpp
@@ -8,25 +8,19 @@
 namespace {
 void throw_error_badrequest(const std::string err_message = "bad request") {
     std::cout << err_message << std::endl;
-    HTTPResponse resp;
-    resp.SetStatusCode(status::bad_request);
-    throw resp;
+    throw status::bad_request;
 }
 
 void throw_error_method_not_allowed(
     const std::string err_message = "method not allowed") {
     std::cout << err_message << std::endl;
-    HTTPResponse resp;
-    resp.SetStatusCode(status::method_not_allowed);
-    throw resp;
+    throw status::method_not_allowed;
 }
 
 void throw_error_version_not_supported(
     const std::string err_message = "version not supported") {
     std::cout << err_message << std::endl;
-    HTTPResponse resp;
-    resp.SetStatusCode(status::validate_version_not_suppoted);
-    throw resp;
+    throw status::validate_version_not_suppoted;
 }
 
 // token  = 1*tchar

--- a/src/request/parse.cpp
+++ b/src/request/parse.cpp
@@ -1,11 +1,16 @@
+#include "DefaultErrorPage.hpp"
 #include "HTTPParser.hpp"
+#include "HTTPResponse.hpp"
+#include "HTTPStatus.hpp"
 #include <iostream>
 #include <sstream>
 
 namespace {
 void throw_error_badrequest(const std::string err_message = "bad request") {
-    /* req.SetStatus(HTTPRequest::status_bad_request); */
-    throw std::runtime_error(err_message);
+    std::cout << err_message << std::endl;
+    HTTPResponse resp;
+    resp.SetStatusCode(status::bad_request);
+    throw resp;
 }
 
 void throw_error_method_not_allowed(

--- a/src/request/parse.cpp
+++ b/src/request/parse.cpp
@@ -6,18 +6,18 @@
 #include <sstream>
 
 namespace {
-void throw_error_badrequest(const std::string err_message = "bad request") {
+void throw_code_badrequest(const std::string err_message = "bad request") {
     std::cerr << err_message << std::endl;
     throw status::bad_request;
 }
 
-void throw_error_method_not_allowed(
+void throw_code_method_not_allowed(
     const std::string err_message = "method not allowed") {
     std::cerr << err_message << std::endl;
     throw status::method_not_allowed;
 }
 
-void throw_error_version_not_supported(
+void throw_code_version_not_supported(
     const std::string err_message = "version not supported") {
     std::cerr << err_message << std::endl;
     throw status::version_not_suppoted;
@@ -29,13 +29,13 @@ void throw_error_version_not_supported(
 //       / DIGIT / ALPHA
 void validate_token(const std::string& token) {
     if (token.empty()) {
-        throw_error_badrequest("empty token");
+        throw_code_badrequest("empty token");
     }
     const std::string special = "!#$%&'*+-.^_`|~";
     for (std::string::const_iterator it = token.begin(); it != token.end();
          it++) {
         if (!std::isalnum(*it) && special.find(*it) == special.npos) {
-            throw_error_badrequest("error token");
+            throw_code_badrequest("error token");
         }
     }
 }
@@ -46,7 +46,7 @@ void validate_method(const std::string& method) {
     for (std::string::const_iterator it = method.begin(); it != method.end();
          it++) {
         if (!std::isupper(*it) && *it != '_' && *it != '-') {
-            throw_error_badrequest("error method");
+            throw_code_badrequest("error method");
         }
     }
 }
@@ -54,7 +54,7 @@ void validate_method(const std::string& method) {
 void validate_request_target(const std::string& request_target) {
     // TODO: バリデート
     if (request_target.empty()) {
-        throw_error_badrequest("error request target");
+        throw_code_badrequest("error request target");
     }
 }
 
@@ -69,17 +69,17 @@ bool isdigit(const std::string& str) {
 
 void validate_version(const std::string& version) {
     if (version.empty()) {
-        throw_error_badrequest("error HTTP version");
+        throw_code_badrequest("error HTTP version");
     }
 
     std::string::size_type pos = version.find("/");
     if (pos == version.npos) {
-        throw_error_badrequest("error not exist slash");
+        throw_code_badrequest("error not exist slash");
     }
 
     std::string name = version.substr(0, pos);
     if (name != "HTTP") {
-        throw_error_badrequest("error protocol name");
+        throw_code_badrequest("error protocol name");
     }
 
     std::string            digit   = version.substr(pos + 1);
@@ -88,7 +88,7 @@ void validate_version(const std::string& version) {
     // dotがあるか
     // dotが複数ないか
     if (dot_pos == digit.npos || dot_pos != digit.find_last_of('.')) {
-        throw_error_badrequest("error version");
+        throw_code_badrequest("error version");
     }
 
     std::string before_dot = digit.substr(0, dot_pos);
@@ -97,27 +97,27 @@ void validate_version(const std::string& version) {
     // dotの前後が数字か
     if (before_dot.empty() || after_dot.empty() || !isdigit(before_dot) ||
         !isdigit(after_dot)) {
-        throw_error_badrequest("error version");
+        throw_code_badrequest("error version");
     }
 }
 
 void validate_host(const HTTPRequest& req) {
     // TODO: find使って調べる
     if (req.GetHeaderValue("Host").empty()) {
-        throw_error_badrequest("empty host");
+        throw_code_badrequest("empty host");
     }
 }
 
 void validate_version_not_suppoted(const std::string& version) {
     if (version != "HTTP/1.1") {
-        throw_error_version_not_supported();
+        throw_code_version_not_supported();
     }
 }
 
 void validate_method_not_allowed(const HTTPRequest& req) {
     if (req.GetMethod() != "GET" && req.GetMethod() != "POST" &&
         req.GetMethod() != "DELETE") {
-        throw_error_method_not_allowed();
+        throw_code_method_not_allowed();
     }
 }
 
@@ -152,7 +152,7 @@ void parse_header_line(HTTPRequest& req, const std::string& line) {
 
     value = trim_space(value);
     if (value.find_first_of(HTTPRequest::crlf) != value.npos) {
-        throw_error_badrequest("error value");
+        throw_code_badrequest("error value");
     }
 
     req.SetHeader(key, value);

--- a/src/response/DefaultErrorPage.hpp
+++ b/src/response/DefaultErrorPage.hpp
@@ -5,30 +5,31 @@
 namespace DefaultErrorPage {
 
 const std::string bad_request =
-    std::string("<html>\r\n") +
-    std::string("<head><title>400 Bad Request</title></head>\r\n") +
-    std::string("<body>\r\n") +
-    std::string("<center><h1>400 Bad Request</h1></center>\r\n") +
-    std::string("<hr><center>webserv</center>\r\n") +
-    std::string("</body>\r\n") + std::string("</html>\r\n");
+    "<html>\r\n"
+    "<head><title>400 Bad Request</title></head>\r\n"
+    "<body>\r\n"
+    "<center><h1>400 Bad Request</h1></center>\r\n"
+    "<hr><center>webserv</center>\r\n"
+    "</body>\r\n"
+    "</html>\r\n";
 
 const std::string method_not_allowed =
-    std::string("<html>\r\n") +
-    std::string("<head><title>405 Not Allowed</title></head>\r\n") +
-    std::string("<body>\r\n") +
-    std::string("<center><h1>405 Not Allowed</h1></center>\r\n") +
-    std::string("<hr><center>webserv</center>\r\n") +
-    std::string("</body>\r\n") + std::string("</html>\r\n");
+    "<html>\r\n"
+    "<head><title>405 Not Allowed</title></head>\r\n"
+    "<body>\r\n"
+    "<center><h1>405 Not Allowed</h1></center>\r\n"
+    "<hr><center>webserv</center>\r\n"
+    "</body>\r\n"
+    "</html>\r\n";
 
 const std::string version_not_suppoted =
-    std::string("<html>\r\n") +
-    std::string(
-        "<head><title>505 HTTP Version Not Supported</title></head>\r\n") +
-    std::string("<body>\r\n") +
-    std::string(
-        "<center><h1>505 HTTP Version Not Supported</h1></center>\r\n") +
-    std::string("<hr><center>webserv</center>\r\n") +
-    std::string("</body>\r\n") + std::string("</html>\r\n");
+    "<html>\r\n"
+    "<head><title>505 HTTP Version Not Supported</title></head>\r\n"
+    "<body>\r\n"
+    "<center><h1>505 HTTP Version Not Supported</h1></center>\r\n"
+    "<hr><center>webserv</center>\r\n"
+    "</body>\r\n"
+    "</html>\r\n";
 } // namespace DefaultErrorPage
 
 #endif // DEFAULT_ERROR_PAGE_HPP

--- a/src/response/DefaultErrorPage.hpp
+++ b/src/response/DefaultErrorPage.hpp
@@ -3,6 +3,7 @@
 #include <string>
 
 namespace DefaultErrorPage {
+
 const std::string bad_request =
     std::string("<html>\r\n") +
     std::string("<head><title>400 Bad Request</title></head>\r\n") +
@@ -10,6 +11,24 @@ const std::string bad_request =
     std::string("<center><h1>400 Bad Request</h1></center>\r\n") +
     std::string("<hr><center>webserv</center>\r\n") +
     std::string("</body>\r\n") + std::string("</html>\r\n");
-}
+
+const std::string method_not_allowed =
+    std::string("<html>\r\n") +
+    std::string("<head><title>405 Not Allowed</title></head>\r\n") +
+    std::string("<body>\r\n") +
+    std::string("<center><h1>405 Not Allowed</h1></center>\r\n") +
+    std::string("<hr><center>webserv</center>\r\n") +
+    std::string("</body>\r\n") + std::string("</html>\r\n");
+
+const std::string version_not_suppoted =
+    std::string("<html>\r\n") +
+    std::string(
+        "<head><title>505 HTTP Version Not Supported</title></head>\r\n") +
+    std::string("<body>\r\n") +
+    std::string(
+        "<center><h1>505 HTTP Version Not Supported</h1></center>\r\n") +
+    std::string("<hr><center>webserv</center>\r\n") +
+    std::string("</body>\r\n") + std::string("</html>\r\n");
+} // namespace DefaultErrorPage
 
 #endif // DEFAULT_ERROR_PAGE_HPP

--- a/src/response/DefaultErrorPage.hpp
+++ b/src/response/DefaultErrorPage.hpp
@@ -1,0 +1,15 @@
+#ifndef DEFAULT_ERROR_PAGE_HPP
+#define DEFAULT_ERROR_PAGE_HPP
+#include <string>
+
+namespace DefaultErrorPage {
+const std::string bad_request =
+    std::string("<html>\r\n") +
+    std::string("<head><title>400 Bad Request</title></head>\r\n") +
+    std::string("<body>\r\n") +
+    std::string("<center><h1>400 Bad Request</h1></center>\r\n") +
+    std::string("<hr><center>webserv</center>\r\n") +
+    std::string("</body>\r\n") + std::string("</html>\r\n");
+}
+
+#endif // DEFAULT_ERROR_PAGE_HPP

--- a/src/response/HTTPStatus.hpp
+++ b/src/response/HTTPStatus.hpp
@@ -5,11 +5,11 @@ namespace status {
 
 typedef int code;
 
-const code ok                            = 200;
-const code bad_request                   = 400;
-const code not_found                     = 404;
-const code method_not_allowed            = 405;
-const code validate_version_not_suppoted = 505;
+const code ok                   = 200;
+const code bad_request          = 400;
+const code not_found            = 404;
+const code method_not_allowed   = 405;
+const code version_not_suppoted = 505;
 } // namespace status
 
 #endif // HTTPSTATUS_HPP

--- a/src/response/HTTPStatus.hpp
+++ b/src/response/HTTPStatus.hpp
@@ -2,11 +2,14 @@
 #define HTTPSTATUS_HPP
 
 namespace status {
-const int ok                            = 200;
-const int bad_request                   = 400;
-const int not_found                     = 404;
-const int method_not_allowed            = 405;
-const int validate_version_not_suppoted = 505;
+
+typedef int code;
+
+const code ok                            = 200;
+const code bad_request                   = 400;
+const code not_found                     = 404;
+const code method_not_allowed            = 405;
+const code validate_version_not_suppoted = 505;
 } // namespace status
 
 #endif // HTTPSTATUS_HPP


### PR DESCRIPTION
## やったこと

- HTTPリクエストをParseしている途中で起こるエラーについてハンドリングしました。
- ミーティングではHTTPResponseクラスを投げる話でしたが、SendErrorクラス内でbodyをセットする必要があり、完全な状態のResponseを投げることができないので、status codeを投げ、SendErrorクラスでHTTPResponseを作成するようにしました。

```mermaid
graph TD
    A[HTTPParser::update_state関数でstatus::codeをthrow] --> B(RecvRequestクラス内でcatch)
    B --> C[RecvRequestのStreamSocketとstatus::codeをペアにしてthrow]
    C --> D[EventExecutorクラス内でcatch]
    D --> E[next_eventをSendErrorイベントに置き換える]
    E --> F{configにエラーページの項目があるか}
    F --> |ない場合| G[SendResponseイベントを登録]
    F --> |ある場合| H[ReadFileイベントを登録]
```

## やらないこと

- configのデフォルトエラーページの項目を見て存在したらReadFileのイベント作成する

## 動作確認
telnetでそれぞれのエラーレスポンスが返ってきてるか確認した

```
❯ telnet localhost 5000
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
a
HTTP/1.1 400 Bad Request
Content-Length: 152

<html>
<head><title>400 Bad Request</title></head>
<body>
<center><h1>400 Bad Request</h1></center>
<hr><center>webserv</center>
</body>
</html>


❯ telnet localhost 5000
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
HOGE / HTTP/1.1
Host:localhost

HTTP/1.1 405
Content-Length: 152

<html>
<head><title>405 Not Allowed</title></head>
<body>
<center><h1>405 Not Allowed</h1></center>
<hr><center>webserv</center>
</body>
</html>
Connection closed by foreign host.
❯ telnet localhost 5000
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
GET / HTTP/3.0
Host:localhost

HTTP/1.1 505
Content-Length: 182

<html>
<head><title>505 HTTP Version Not Supported</title></head>
<body>
<center><h1>505 HTTP Version Not Supported</h1></center>
<hr><center>webserv</center>
</body>
</html>

```

## その他

- src/event/mode/RecvRequest.cppでpairをthrowしているところ、関数にしたいという話でしたが、どこに関数定義するべきか迷って保留してます。いい案あれば教えてください。
- src/response/DefaultErrorPage.hppのそれぞれのstringの定義、もう少しいい感じに書ける方法知りませんか


## issues

about : #59 

close #59
