### PR TITLE
:+1: configをStreamSocketに保持させる

### DIFF
--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -94,6 +94,10 @@ void Config::addServerConfig(const ServerConfig& server_config) {
         target->second.push_back(server_config);
 }
 
+std::map<int, std::vector<const ServerConfig> > Config::GetServerConfigs() {
+    return server_configs_;
+}
+
 void Config::printConfigs() {
     std::map<int, std::vector<const ServerConfig> >::iterator map_itr =
         server_configs_.begin();

--- a/src/config/Config.hpp
+++ b/src/config/Config.hpp
@@ -19,7 +19,8 @@ public:
                                           DERECTIVE_MAP;
     static const std::vector<std::string> ALLOWED_METHODS;
     static void addServerConfig(const ServerConfig& server_config);
-    static void printConfigs();
+    static std::map<int, std::vector<const ServerConfig> > GetServerConfigs();
+    static void                                            printConfigs();
 
 protected:
     Config();

--- a/src/event/mode/AcceptConn.cpp
+++ b/src/event/mode/AcceptConn.cpp
@@ -15,7 +15,7 @@ AcceptConn::AcceptConn()
 
 AcceptConn::AcceptConn(ListeningSocket listener)
     : IOEvent(listener.GetSocketFd(), ACCEPT_CONNECTION), listener_(listener),
-      stream_sock_(StreamSocket()) {}
+      stream_sock_(StreamSocket(listener.GetServerConfig())) {}
 
 AcceptConn::~AcceptConn() {}
 

--- a/src/event/mode/RecvRequest.cpp
+++ b/src/event/mode/RecvRequest.cpp
@@ -64,7 +64,7 @@ IOEvent* RecvRequest::prepareResponse() {
     if (req_.GetMethod() == "GET") {
         // Uriのパスや拡張子によって ReadFile or ReadCGI
         if (CGI::IsCGI(req_.GetRequestTarget())) {
-            CGI cgi(req_);
+            class CGI cgi(req_);
             cgi.Run();
             new_event = new ReadCGI(cgi.FdForReadFromCGI(), stream_, req_);
         } else {
@@ -76,7 +76,7 @@ IOEvent* RecvRequest::prepareResponse() {
         return new_event;
     } else if (req_.GetMethod() == "POST") {
         if (CGI::IsCGI(req_.GetRequestTarget())) {
-            CGI cgi(req_);
+            class CGI cgi(req_);
             cgi.Run();
             new_event = new WriteCGI(cgi, stream_, req_);
             this->Unregister();

--- a/src/event/mode/WriteCGI.cpp
+++ b/src/event/mode/WriteCGI.cpp
@@ -14,7 +14,7 @@
 
 #include <iostream>
 
-WriteCGI::WriteCGI(CGI cgi, StreamSocket stream, HTTPRequest req)
+WriteCGI::WriteCGI(class CGI cgi, StreamSocket stream, HTTPRequest req)
     : IOEvent(cgi.FdForWriteToCGI(), WRITE_CGI), cgi_(cgi), stream_(stream),
       req_(req) {}
 

--- a/src/event/mode/WriteCGI.hpp
+++ b/src/event/mode/WriteCGI.hpp
@@ -8,7 +8,7 @@
 
 class WriteCGI : public IOEvent {
 public:
-    WriteCGI(CGI cgi, StreamSocket stream, HTTPRequest req);
+    WriteCGI(class CGI cgi, StreamSocket stream, HTTPRequest req);
     virtual ~WriteCGI();
 
     virtual void     Run();
@@ -20,7 +20,7 @@ private:
     WriteCGI();
 
 private:
-    CGI          cgi_;
+    class CGI    cgi_;
     StreamSocket stream_;
     HTTPRequest  req_;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,8 +4,11 @@
 #include "ListeningSocket.hpp"
 
 #include "AcceptConn.hpp"
+#include "Config.hpp"
+#include "ConfigParser.hpp"
 #include "IOEvent.hpp"
 #include <unistd.h>
+#include <vector>
 
 #include <iostream>
 
@@ -14,20 +17,39 @@ int main(void) {
         EventExecutor executor;
         executor.Init();
 
-        ListeningSocket ls;
-        ls.Bind("127.0.0.1", 5000);
-        ls.Listen();
+        ConfigParser::parseConfigFile();
+        std::map<int, std::vector<const ServerConfig> > server_configs =
+            Config::instance()->GetServerConfigs();
 
-        // イベントの追加
-        IOEvent* event = new AcceptConn(ls);
-        event->Register();
+        std::map<int, std::vector<const ServerConfig> >::const_iterator it_end =
+            server_configs.end();
+
+        std::vector<ListeningSocket> listeners;
+        for (std::map<int, std::vector<const ServerConfig> >::const_iterator
+                 it = server_configs.begin();
+             it != it_end; it++) {
+
+            int                             port    = it->first;
+            std::vector<const ServerConfig> configs = it->second;
+
+            ListeningSocket ls(configs);
+            ls.Bind("127.0.0.1", port);
+            ls.Listen();
+            listeners.push_back(ls);
+
+            IOEvent* event = new AcceptConn(ls);
+            event->Register();
+        }
 
         while (true) {
             executor.ProcessEvent();
         }
 
-        ls.Close();
-        // 全てのsocketをclose
+        // 全てのListeningSocketをclose
+        for (std::vector<ListeningSocket>::iterator it = listeners.begin();
+             it != listeners.end(); it++) {
+            it->Close();
+        }
         executor.ShutDown();
     } catch (const std::exception& e) {
         std::cerr << e.what() << std::endl;

--- a/src/socket/ListeningSocket.cpp
+++ b/src/socket/ListeningSocket.cpp
@@ -6,10 +6,16 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h> // close()
+#include <vector>
 
+#include "ServerConfig.hpp"
+#include "Socket.hpp"
 #include "SysError.hpp"
 
-ListeningSocket::ListeningSocket() { type_ = LISTENING; }
+ListeningSocket::ListeningSocket() : Socket(LISTENING) {}
+
+ListeningSocket::ListeningSocket(std::vector<const ServerConfig> config)
+    : Socket(LISTENING), config_(config) {}
 
 ListeningSocket::~ListeningSocket() {}
 

--- a/src/socket/ListeningSocket.hpp
+++ b/src/socket/ListeningSocket.hpp
@@ -2,18 +2,26 @@
 #define LISTENING_SOCKET_HPP
 
 #include <string>
+#include <vector>
 
+#include "ServerConfig.hpp"
 #include "Socket.hpp"
 class ListeningSocket : public Socket {
 public:
     ListeningSocket();
+    ListeningSocket(std::vector<const ServerConfig> config);
     virtual ~ListeningSocket();
+
+    const std::vector<const ServerConfig> GetServerConfig() const {
+        return config_;
+    }
 
     void Bind(const std::string& ip, int port);
     void Listen();
     void Close();
 
 private:
+    const std::vector<const ServerConfig> config_;
 };
 
 #endif

--- a/src/socket/StreamSocket.hpp
+++ b/src/socket/StreamSocket.hpp
@@ -1,13 +1,25 @@
 #ifndef STREAM_SOCKET_HPP
 #define STREAM_SOCKET_HPP
 
+#include <vector>
+
+#include "ServerConfig.hpp"
 #include "Socket.hpp"
 
 class StreamSocket : public Socket {
 public:
     StreamSocket() : Socket(STREAM) {}
+    StreamSocket(std::vector<const ServerConfig> config)
+        : Socket(STREAM), config_(config) {}
     StreamSocket(int fd) : Socket(fd, STREAM) {}
     virtual ~StreamSocket() {}
+
+    const std::vector<const ServerConfig> GetServerConfig() const {
+        return config_;
+    }
+
+private:
+    const std::vector<const ServerConfig> config_;
 };
 
 #endif


### PR DESCRIPTION
## やったこと

- configをmainで初期化し、StreamSocketにconfigを持たせる

**main.cpp**
```cpp
ConfigParser::parseConfigFile();
std::map<int, std::vector<const ServerConfig> > server_configs = Config::instance()->GetServerConfigs();
std::map<int, std::vector<const ServerConfig> >::const_iterator it_end = server_configs.end();
for (std::map<int, std::vector<const ServerConfig> >::const_iterator it = server_configs.begin(); it != it_end; it++) {
     // port毎にConfigを取得
      int                             port    = it->first;
      std::vector<const ServerConfig> configs = it->second;

     // ListeningSocketにconfigを与えて初期化
      ListeningSocket ls(configs);
      ls.Bind("127.0.0.1", port);
      ls.Listen();

     // AcceptConn内でStreamSocketにconfigを与えて初期化
      IOEvent* event = new AcceptConn(ls);
      event->Register();
}
```
**Confiig取得方法**
Event内で
```cpp
std::vector<const ServerConfig> config = stream.GetServerConfig();
```
`GetServerConfig()`で取得することができます。

## やらないこと

- Configを用いた操作などは行なっていません。取得のみが可能です。

## 動作確認
- 今まではポート5000のみでしたが、configファイルからポートを読み込んでいます。
- `default.conf`ではポート`2121`と`4242`になっています。
```bash
$ ./webserv
```
別ターミナルで `telnet localhost 2121`
```bash
$ telnet localhost 2121
Trying ::1...
telnet: connect to address ::1: Connection refused
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
GET / HTTP/1.1
HOST: localhost

HTTP/1.1 200 OK
Content-Length: 219
Server: Webserv/1.0.0

<!DOCTYPE html>
<html lang="ja">
        <head>
                <meta charset="UTF-8">
                <link rel="icon" href="data:image/x-icon;," type="image/x-icon">
                <title>INDEX.HTML</title>
        </head>
        <body>
                <h1>HELLO WORLD!</h1>
        </body>
</html>
```
別ターミナルで `telnet localhost 4242`
```bash 
$ telnet localhost 4242
Trying ::1...
telnet: connect to address ::1: Connection refused
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
GET /docs/cgi/hello.py HTTP/1.1
HOST: localhost

HTTP/1.1 200 OK
Content-Length: 687
Server: Webserv/1.0.0

----Args----
./docs/cgi/hello.py
----Environ----
environ({'AUTH_TYPE': '', 'CONTENT_LENGTH': '0', 'CONTENT_TYPE': '', 'GATEWAY_INTERFACE': '', 'PATH_INFO': '', 'PATH_TRANSLATED': '', 'QUERY_STRING': '', 'REMOTE_ADDR': '', 'REMOTE_HOST': '', 'REMOTE_IDENT': '', 'REMOTE_USER': '', 'REQUEST_METHOD': '', 'SCRIPT_NAME': '', 'SERVER_NAME': '', 'SERVER_PORT': '', 'SERVER_PROTOCOL': '', 'SERVER_SOFTWARE': '', '__CF_USER_TEXT_ENCODING': '0x1F5:0x1:0xE', 'SDKROOT': '/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk', 'CPATH': '/usr/local/include', 'LIBRARY_PATH': '/usr/local/lib', '__PYVENV_LAUNCHER__': '/Applications/Xcode.app/Contents/Developer/usr/bin/python3', 'LC_CTYPE': 'UTF-8'})
```

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

## issues

about : #68 

close #68
