### PR TITLE
Feature/config

### DIFF
--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -30,11 +30,6 @@ Config& Config::operator=(const Config& src) {
     return (*this);
 }
 
-const std::map<int, std::vector<const ServerConfig> >
-Config::getServerConfigs() {
-    return (server_configs_);
-}
-
 const std::map<const e_drctv_cd, std::string> Config::createDerectiveNames() {
     std::map<const e_drctv_cd, std::string> directive_names;
 
@@ -91,7 +86,7 @@ void Config::addServerConfig(const ServerConfig& server_config) {
     int port = server_config.getListen();
     std::map<int, std::vector<const ServerConfig> >::iterator target =
         server_configs_.find(port);
-    (void)target;
+
     if (target == server_configs_.end()) {
         std::vector<const ServerConfig> new_servers(1, server_config);
         server_configs_.insert(std::make_pair(port, new_servers));
@@ -128,12 +123,13 @@ void Config::printConfigs() {
                 it++;
             }
 
-            size_t                      j = -1;
-            std::vector<LocationConfig> location_configs =
+            std::map<const std::string, const LocationConfig> location_configs =
                 server_config.getLocationConfigs();
-            while (++j < location_configs.size()) {
+            std::map<const std::string, const LocationConfig>::iterator
+                location_it = location_configs.begin();
+            while (location_it != location_configs.end()) {
                 std::cout << "\t--------- location config" << std::endl;
-                LocationConfig location_config = location_configs[j];
+                LocationConfig location_config = location_it->second;
                 std::cout << "\ttarget\t\t:" << location_config.getTarget()
                           << std::endl;
                 std::cout << "\tallowed method\t:";
@@ -161,6 +157,7 @@ void Config::printConfigs() {
                 while (++l < cgi_extensions.size())
                     std::cout << " " << cgi_extensions[l];
                 std::cout << std::endl;
+                location_it++;
             }
             sc_itr++;
         }

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -30,6 +30,11 @@ Config& Config::operator=(const Config& src) {
     return (*this);
 }
 
+const std::map<int, std::vector<const ServerConfig> >
+Config::getServerConfigs() {
+    return (server_configs_);
+}
+
 const std::map<const e_drctv_cd, std::string> Config::createDerectiveNames() {
     std::map<const e_drctv_cd, std::string> directive_names;
 

--- a/src/config/Config.hpp
+++ b/src/config/Config.hpp
@@ -19,6 +19,8 @@ public:
                                           DERECTIVE_MAP;
     static const std::vector<std::string> ALLOWED_METHODS;
     static void addServerConfig(const ServerConfig& server_config);
+    static const std::map<int, std::vector<const ServerConfig> >
+                getServerConfigs();
     static void printConfigs();
 
 protected:

--- a/src/config/ConfigParser.cpp
+++ b/src/config/ConfigParser.cpp
@@ -69,8 +69,7 @@ void ConfigParser::parseConfigFile(const std::string confPath) {
     try {
         ConfigValidator::validateConfigFile(tokens);
         setupConfig(tokens);
-        Config::printConfigs();
-    } catch (...) { throw }
+    } catch (...) { throw; }
 }
 
 void ConfigParser::setupConfig(std::vector<std::string> tokens) {

--- a/src/config/ConfigParser.cpp
+++ b/src/config/ConfigParser.cpp
@@ -69,7 +69,6 @@ void ConfigParser::parseConfigFile(const std::string confPath) {
     try {
         ConfigValidator::validateConfigFile(tokens);
         setupConfig(tokens);
-        Config::printConfigs();
     } catch (...) { throw; }
 }
 

--- a/src/config/ServerConfig.cpp
+++ b/src/config/ServerConfig.cpp
@@ -15,7 +15,7 @@ ServerConfig& ServerConfig::operator=(const ServerConfig& src) {
         this->server_name_          = src.server_name_;
         this->max_client_body_size_ = src.max_client_body_size_;
         this->error_page_           = src.error_page_;
-        this->location_configs      = src.location_configs;
+        this->location_configs_     = src.location_configs_;
     }
     return (*this);
 }
@@ -35,7 +35,8 @@ void ServerConfig::setErrorPage(int status_code, std::string location) {
 }
 
 void ServerConfig::setLocationConfigs(LocationConfig& location_config) {
-    this->location_configs.push_back(location_config);
+    this->location_configs_.insert(
+        std::make_pair(location_config.getTarget(), location_config));
 }
 
 int ServerConfig::getListen() const { return (this->listen_); }
@@ -50,6 +51,7 @@ std::map<int, std::string> ServerConfig::getErrorPage() const {
     return (this->error_page_);
 }
 
-std::vector<LocationConfig> ServerConfig::getLocationConfigs() const {
-    return (this->location_configs);
+std::map<const std::string, const LocationConfig>
+ServerConfig::getLocationConfigs() const {
+    return (this->location_configs_);
 }

--- a/src/config/ServerConfig.hpp
+++ b/src/config/ServerConfig.hpp
@@ -21,18 +21,19 @@ public:
     void setErrorPage(int status_code, std::string location);
     void setLocationConfigs(LocationConfig& location_config);
 
-    int                         getListen() const;
-    std::string                 getServerName() const;
-    std::string                 getMaxClientBodySize() const;
-    std::map<int, std::string>  getErrorPage() const;
-    std::vector<LocationConfig> getLocationConfigs() const;
+    int                        getListen() const;
+    std::string                getServerName() const;
+    std::string                getMaxClientBodySize() const;
+    std::map<int, std::string> getErrorPage() const;
+    std::map<const std::string, const LocationConfig>
+    getLocationConfigs() const;
 
 private:
-    int                         listen_;
-    std::string                 server_name_;
-    std::string                 max_client_body_size_;
-    std::map<int, std::string>  error_page_;
-    std::vector<LocationConfig> location_configs;
+    int                                               listen_;
+    std::string                                       server_name_;
+    std::string                                       max_client_body_size_;
+    std::map<int, std::string>                        error_page_;
+    std::map<const std::string, const LocationConfig> location_configs_;
 };
 
 #endif


### PR DESCRIPTION
## やったこと
- LocationConfigをmap<ターゲット, LocationConfig>で持つように変更
ターゲット：パスのことです。下記でいう「/hoge」
```
location /hoge {
    ...
}
```
下記の感じで取得できます。
```
// ServerConfig内のLocationConfigを全て取得
std::map<const std::string, const LocationConfig> location_configs = server_config.getLocationConfigs();

// LocationConfig走査
std::map<const std::string, const LocationConfig>::iterator location_it = location_configs.begin();
while (location_it != location_configs.end()) {
    ...
}
```

## 動作確認
動作自体は変わりません。
