### PR TITLE
リクエストターゲットのサーバ内でのローカルパスを作成

### DIFF
--- a/config/multi_location.conf
+++ b/config/multi_location.conf
@@ -1,0 +1,37 @@
+
+server {
+  listen 2121;
+  server_name server_name;
+  max_client_body_size 1m;
+
+  location / {
+    alias ./
+  }
+
+  location /a/ {
+    alias ./a/
+  }
+
+  location /a/b/ {
+    alias ./a/b/
+  }
+
+  location /a/b/c/ {
+    alias ./a/b/c/
+  }
+
+  error_page 404 /custom_404.html;
+  location /custom_404.html {
+    alias /opt/nginx/html;
+  }
+
+  error_page 500 /50x.html;
+  location /50x.html {
+  }
+}
+
+server {
+  listen 2121;
+  server_name default.com;
+  max_client_body_size 10m;
+}

--- a/src/uri/URI.cpp
+++ b/src/uri/URI.cpp
@@ -15,6 +15,8 @@ void URI::Init() {
     divideRawTarget();
     // query_からargsを作成する
     storeArgsFromQuery();
+    // location_configを決定し、local_pathを作成する
+    // findLocalPath();
 }
 
 // raw_target を <raw_path_> '?' <query_> に分割する

--- a/src/uri/URI.cpp
+++ b/src/uri/URI.cpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <utility>
 
+#include "LocationConfig.hpp"
 #include "ServerConfig.hpp"
 
 URI::URI(const ServerConfig& server_config, const std::string target)
@@ -15,8 +16,10 @@ void URI::Init() {
     divideRawTarget();
     // query_からargsを作成する
     storeArgsFromQuery();
-    // location_configを決定し、local_pathを作成する
-    // findLocalPath();
+    // location_configを探す
+    findLocationConfig();
+    // location_configのtargetからlocal_pathを作成する
+    storeLocalPath();
 }
 
 // raw_target を <raw_path_> '?' <query_> に分割する
@@ -86,4 +89,43 @@ std::vector<std::string> URI::split(std::string str, std::string sep) {
     }
 
     return list;
+}
+
+void URI::findLocationConfig() {
+    typedef std::map<const std::string, const LocationConfig> location_map;
+    typedef std::map<const std::string,
+                     const LocationConfig>::const_reverse_iterator
+        const_reverse_iterator;
+
+    const location_map& locations = server_config_.getLocationConfigs();
+
+    // location configを決定する
+    std::string            location_target_dir;
+    const_reverse_iterator it_end = locations.rend();
+    for (const_reverse_iterator it = locations.rbegin(); it != it_end; it++) {
+        location_target_dir = it->first;
+        if (*location_target_dir.rbegin() != '/') {
+            location_target_dir += "/";
+        }
+
+        // location の target と
+        // raw_path_のディレクトリのパス部分が最大長で一致するもの
+        if (location_target_dir.length() <= raw_path_.length() &&
+            raw_path_.substr(0, location_target_dir.length()) ==
+                location_target_dir) {
+            location_config_ = it->second;
+            break;
+        }
+    }
+}
+
+void URI::storeLocalPath() {
+    std::string location_target_dir = location_config_.getTarget();
+    if (*location_target_dir.rbegin() != '/') {
+        location_target_dir += "/";
+    }
+
+    // local_path_を設定する
+    local_path_ = location_config_.getAlias() +
+                  raw_path_.substr(location_target_dir.length());
 }

--- a/src/uri/URI.hpp
+++ b/src/uri/URI.hpp
@@ -15,19 +15,22 @@ public:
 
     void Init();
 
-    const ServerConfig&      GetServerConfig() const { return server_config_; }
-    const std::string        GetRawTarget() const { return raw_target_; }
-    const std::string        GetRawPath() const { return raw_path_; }
-    const std::string        GetQuery() const { return query_; }
-    std::vector<std::string> GetArgs() { return args_; }
+    const ServerConfig& GetServerConfig() const { return server_config_; }
+    const std::string&  GetRawTarget() const { return raw_target_; }
+    const std::string&  GetRawPath() const { return raw_path_; }
+    const std::string&  GetQuery() const { return query_; }
+    const std::vector<std::string>& GetArgs() const { return args_; }
+    const std::string&              GetLocalPath() const { return local_path_; }
 
 private:
     URI();
+
     void divideRawTarget();
+    void storeArgsFromQuery();
+    // void findLocalPath();
+
     std::pair<std::string, std::string>
     divideByTheFirstDelimiterFound(std::string str, std::string delimiter);
-
-    void                     storeArgsFromQuery();
     std::vector<std::string> split(std::string str, std::string sep);
 
 private:

--- a/src/uri/URI.hpp
+++ b/src/uri/URI.hpp
@@ -27,7 +27,8 @@ private:
 
     void divideRawTarget();
     void storeArgsFromQuery();
-    // void findLocalPath();
+    void findLocationConfig();
+    void storeLocalPath();
 
     std::pair<std::string, std::string>
     divideByTheFirstDelimiterFound(std::string str, std::string delimiter);

--- a/test/uri_test.cpp
+++ b/test/uri_test.cpp
@@ -14,7 +14,7 @@ protected:
     virtual void SetUp() {
         typedef std::map<int, std::vector<const ServerConfig> > configs_map;
 
-        ConfigParser::parseConfigFile("./config/duplicated_port.conf");
+        ConfigParser::parseConfigFile("./config/multi_location.conf");
         configs_map servers_map = Config::instance()->GetServerConfigs();
 
         configs_map::const_iterator it = servers_map.begin();
@@ -142,5 +142,63 @@ TEST_F(URITest, storeArgsFromQuery) {
         std::vector<std::string> args = uri.GetArgs();
         std::vector<std::string> ans;
         EXPECT_TRUE(args == ans);
+    }
+}
+
+TEST_F(URITest, findLocalPath) {
+    {
+        URI uri(config, "/txt");
+        uri.Init();
+
+        EXPECT_EQ("./txt", uri.GetLocalPath());
+    }
+
+    {
+        URI uri(config, "/a/txt");
+        uri.Init();
+
+        EXPECT_EQ("./a/txt", uri.GetLocalPath());
+    }
+
+    {
+        URI uri(config, "/a/b/txt");
+        uri.Init();
+
+        EXPECT_EQ("./a/b/txt", uri.GetLocalPath());
+    }
+
+    {
+        URI uri(config, "/a/b/c/txt");
+        uri.Init();
+
+        EXPECT_EQ("./a/b/c/txt", uri.GetLocalPath());
+    }
+
+    {
+        URI uri(config, "/a/d/txt");
+        uri.Init();
+
+        EXPECT_EQ("./a/d/txt", uri.GetLocalPath());
+    }
+
+    {
+        URI uri(config, "/a/b/d/txt");
+        uri.Init();
+
+        EXPECT_EQ("./a/b/d/txt", uri.GetLocalPath());
+    }
+
+    {
+        URI uri(config, "/a/b/c/d/txt");
+        uri.Init();
+
+        EXPECT_EQ("./a/b/c/d/txt", uri.GetLocalPath());
+    }
+
+    {
+        URI uri(config, "/a/../txt");
+        uri.Init();
+
+        EXPECT_EQ("./a/../txt", uri.GetLocalPath());
     }
 }


### PR DESCRIPTION
## やったこと
- URIクラスの`location_config_`と`local_path_`を設定しました。

**重要なところを抜き出したクラス図**
- 上段... クラス名
- 中段... 変数(`-`はprivate、`+`はpublic)
- 下段... メソッド(`-`はprivate、`+`はpublic)

追加部分のみ記述
```mermaid
classDiagram
class URI{
    -string local_path_
    -LocationConfig location_config_
    -findLocationConfig()
    -storeLocationPath()
}
```

**location_config_** ... locationディレクティブのターゲットとリクエストターゲットが最大長で一致するものを`location_config`として保持します。

**local_path_** ... `local_path_`はlocationのターゲットパスとaliasのパスを置換したものを保持します。

リクエスト`/a/b/txt`の場合。
```conf
location /a/ {　   #(1)
    alias ./x/
  }

  location /a/b/ {  #(2)
    alias ./x/y/
  }
```
リクエストのディレクトパス`/a/b/`と最大で一致する`(2)`が`location_config`として採用されます。
`local_path_`は`/a/b/`と`./x/y/`を置換した`./x/y/txt`となります。

## やらないこと

- statなどでファイル情報を持つ
- イベントに持たせる

## 動作確認

- google_test追加とpass

## issues

about : #77 