### PR TITLE
:recycle: clang-ticyをconfigにかける

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,10 @@ WarningsAsErrors: "*"
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase
+  - key:             readability-identifier-naming.ClassConstantCase
+    value:           UPPER_CASE
+  - key:             readability-identifier-naming.ClassMemberSuffix
+    value:           _
   - key:             readability-identifier-naming.EnumCase
     value:           CamelCase
   - key:             readability-identifier-naming.FunctionCase

--- a/src/cgi/CGI.cpp
+++ b/src/cgi/CGI.cpp
@@ -17,9 +17,9 @@
 
 #include <iostream>
 
-const std::map<std::string, std::string> CGI::binaries = CGI::setBinaries();
+const std::map<std::string, std::string> CGI::BINARIES = CGI::setBinaries();
 
-const std::map<std::string, std::string> CGI::commands = CGI::setCommands();
+const std::map<std::string, std::string> CGI::COMMANDS = CGI::setCommands();
 
 CGI::CGI(const URI& uri, const HTTPRequest& req) : uri_(uri), req_(req) {
     // pipeの初期化
@@ -34,7 +34,7 @@ bool CGI::IsCGI(const URI& uri, const std::string& method) {
     const LocationConfig& location_config = uri.GetLocationConfig();
 
     const std::vector<std::string> allowed_methods =
-        location_config.getAllowedMethods();
+        location_config.GetAllowedMethods();
 
     // methodが許可されているか
     if (std::find(allowed_methods.begin(), allowed_methods.end(), method) ==
@@ -49,7 +49,7 @@ bool CGI::IsCGI(const URI& uri, const std::string& method) {
     }
 
     const std::vector<std::string> cgi_extensions =
-        location_config.getCgiExtensions();
+        location_config.GetCgiExtensions();
     // 拡張子がcgi_extentionに含まれているか
     if (std::find(cgi_extensions.begin(), cgi_extensions.end(), extension) ==
         cgi_extensions.end()) {
@@ -83,14 +83,14 @@ void CGI::cgiParseRequest() {}
 
 std::string CGI::makeExecutableBinary() {
     // 拡張子によって実行ファイルのパスを決定する
-    return binaries.find(uri_.GetExtension())->second;
+    return BINARIES.find(uri_.GetExtension())->second;
 }
 
 std::vector<std::string> CGI::makeArgs() {
     std::vector<std::string> args;
 
     // command設定
-    args.push_back(commands.find(uri_.GetExtension())->second);
+    args.push_back(COMMANDS.find(uri_.GetExtension())->second);
     // 実行するスクリプトファイルのパス設定
     args.push_back(uri_.GetLocalPath());
     // 残りの引数設定
@@ -121,9 +121,9 @@ std::vector<std::string> CGI::makeEnvs() {
 
     env_map["REQUEST_METHOD"] = req_.GetMethod();
     env_map["SCRIPT_NAME"]    = uri_.GetRawPath();
-    env_map["SERVER_NAME"]    = uri_.GetServerConfig().getServerName();
+    env_map["SERVER_NAME"]    = uri_.GetServerConfig().GetServerName();
 
-    oss << uri_.GetServerConfig().getListen() << std::flush;
+    oss << uri_.GetServerConfig().GetListen() << std::flush;
     env_map["SERVER_PORT"] = oss.str();
     oss.str("");
     env_map["SERVER_PROTOCOL"] = req_.GetVersion();

--- a/src/cgi/CGI.hpp
+++ b/src/cgi/CGI.hpp
@@ -44,8 +44,8 @@ private:
     int pipe_for_cgi_write_[2];
     int pipe_for_cgi_read_[2];
 
-    static const std::map<std::string, std::string> binaries;
-    static const std::map<std::string, std::string> commands;
+    static const std::map<std::string, std::string> BINARIES;
+    static const std::map<std::string, std::string> COMMANDS;
     static std::map<std::string, std::string>       setBinaries();
     static std::map<std::string, std::string>       setCommands();
 };

--- a/src/config/Config.cpp
+++ b/src/config/Config.cpp
@@ -4,14 +4,14 @@ Config*                                         Config::instance_    = 0;
 const int                                       Config::MAX_PORT_NUM = 65535;
 const std::string                               Config::DELIMITERS   = " {};";
 std::map<int, std::vector<const ServerConfig> > Config::server_configs_;
-const std::map<const e_drctv_cd, std::string>   Config::DERECTIVE_NAMES =
+const std::map<const EDrctvCd, std::string>     Config::DERECTIVE_NAMES =
     Config::createDerectiveNames();
-const std::map<const e_drctv_cd, std::vector<std::string> >
+const std::map<const EDrctvCd, std::vector<std::string> >
     Config::DERECTIVE_MAP = Config::createDerectiveMap();
 const std::vector<std::string> Config::ALLOWED_METHODS =
     Config::createAllowedMethodsVec();
 
-Config* Config::instance() {
+Config* Config::Instance() {
     if (instance_ == 0)
         instance_ = new Config;
     return instance_;
@@ -30,8 +30,8 @@ Config& Config::operator=(const Config& src) {
     return (*this);
 }
 
-const std::map<const e_drctv_cd, std::string> Config::createDerectiveNames() {
-    std::map<const e_drctv_cd, std::string> directive_names;
+const std::map<const EDrctvCd, std::string> Config::createDerectiveNames() {
+    std::map<const EDrctvCd, std::string> directive_names;
 
     directive_names[SRVR]           = "server";
     directive_names[LCTN]           = "location";
@@ -48,12 +48,12 @@ const std::map<const e_drctv_cd, std::string> Config::createDerectiveNames() {
     return (directive_names);
 }
 
-const std::map<const e_drctv_cd, std::vector<std::string> >
+const std::map<const EDrctvCd, std::vector<std::string> >
 Config::createDerectiveMap() {
-    std::map<const e_drctv_cd, std::vector<std::string> > derective_map;
-    std::vector<std::string>                              main_dirs;
-    std::vector<std::string>                              server_dirs;
-    std::vector<std::string>                              location_dirs;
+    std::map<const EDrctvCd, std::vector<std::string> > derective_map;
+    std::vector<std::string>                            main_dirs;
+    std::vector<std::string>                            server_dirs;
+    std::vector<std::string>                            location_dirs;
 
     main_dirs.push_back(DERECTIVE_NAMES.at(SRVR));
     server_dirs.push_back(DERECTIVE_NAMES.at(LCTN));
@@ -82,8 +82,8 @@ const std::vector<std::string> Config::createAllowedMethodsVec() {
     return (allowed_methods);
 }
 
-void Config::addServerConfig(const ServerConfig& server_config) {
-    int port = server_config.getListen();
+void Config::AddServerConfig(const ServerConfig& server_config) {
+    int port = server_config.GetListen();
     std::map<int, std::vector<const ServerConfig> >::iterator target =
         server_configs_.find(port);
 
@@ -98,7 +98,7 @@ std::map<int, std::vector<const ServerConfig> > Config::GetServerConfigs() {
     return server_configs_;
 }
 
-void Config::printConfigs() {
+void Config::PrintConfigs() {
     std::map<int, std::vector<const ServerConfig> >::iterator map_itr =
         server_configs_.begin();
     while (map_itr != server_configs_.end()) {
@@ -108,14 +108,14 @@ void Config::printConfigs() {
         while (sc_itr != map_itr->second.end()) {
             std::cout << "--------- server config ------------" << std::endl;
             ServerConfig server_config = *sc_itr;
-            std::cout << "listen\t\t\t:" << server_config.getListen()
+            std::cout << "listen\t\t\t:" << server_config.GetListen()
                       << std::endl;
-            std::cout << "server name\t\t:" << server_config.getServerName()
+            std::cout << "server name\t\t:" << server_config.GetServerName()
                       << std::endl;
             std::cout << "max client body size\t:"
-                      << server_config.getMaxClientBodySize() << std::endl;
+                      << server_config.GetMaxClientBodySize() << std::endl;
             std::map<int, std::string> error_page =
-                server_config.getErrorPage();
+                server_config.GetErrorPage();
             std::map<int, std::string>::iterator it = error_page.begin();
             while (it != error_page.end()) {
                 std::cout << "error page\t\t:" << it->first << " > "
@@ -124,35 +124,35 @@ void Config::printConfigs() {
             }
 
             std::map<const std::string, const LocationConfig> location_configs =
-                server_config.getLocationConfigs();
+                server_config.GetLocationConfigs();
             std::map<const std::string, const LocationConfig>::iterator
                 location_it = location_configs.begin();
             while (location_it != location_configs.end()) {
                 std::cout << "\t--------- location config" << std::endl;
                 LocationConfig location_config = location_it->second;
-                std::cout << "\ttarget\t\t:" << location_config.getTarget()
+                std::cout << "\ttarget\t\t:" << location_config.GetTarget()
                           << std::endl;
                 std::cout << "\tallowed method\t:";
                 std::vector<std::string> allowed_methods =
-                    location_config.getAllowedMethods();
+                    location_config.GetAllowedMethods();
                 size_t k = -1;
                 while (++k < allowed_methods.size())
                     std::cout << " " << allowed_methods[k];
                 std::cout << std::endl;
-                std::cout << "\talias\t\t:" << location_config.getAlias()
+                std::cout << "\talias\t\t:" << location_config.GetAlias()
                           << std::endl;
                 std::cout << "\tauto index\t:"
-                          << (location_config.getAutoIndex() == ON ? "on"
+                          << (location_config.GetAutoIndex() == ON ? "on"
                                                                    : "off")
                           << std::endl;
-                std::cout << "\tindex\t\t:" << location_config.getIndex()
+                std::cout << "\tindex\t\t:" << location_config.GetIndex()
                           << std::endl;
                 std::cout << "\treturn\t\t:";
-                std::pair<int, std::string> rtrn = location_config.getReturn();
+                std::pair<int, std::string> rtrn = location_config.GetReturn();
                 std::cout << rtrn.first << " > " << rtrn.second << std::endl;
                 std::cout << "\tcgi extension\t:";
                 std::vector<std::string> cgi_extensions =
-                    location_config.getCgiExtensions();
+                    location_config.GetCgiExtensions();
                 size_t l = -1;
                 while (++l < cgi_extensions.size())
                     std::cout << " " << cgi_extensions[l];

--- a/src/config/Config.hpp
+++ b/src/config/Config.hpp
@@ -11,16 +11,16 @@
 
 class Config {
 public:
-    static Config*                                       instance();
-    static const std::string                             DELIMITERS;
-    static const int                                     MAX_PORT_NUM;
-    static const std::map<const e_drctv_cd, std::string> DERECTIVE_NAMES;
-    static const std::map<const e_drctv_cd, std::vector<std::string> >
+    static Config*                                     Instance();
+    static const std::string                           DELIMITERS;
+    static const int                                   MAX_PORT_NUM;
+    static const std::map<const EDrctvCd, std::string> DERECTIVE_NAMES;
+    static const std::map<const EDrctvCd, std::vector<std::string> >
                                           DERECTIVE_MAP;
     static const std::vector<std::string> ALLOWED_METHODS;
-    static void addServerConfig(const ServerConfig& server_config);
+    static void AddServerConfig(const ServerConfig& server_config);
     static std::map<int, std::vector<const ServerConfig> > GetServerConfigs();
-    static void                                            printConfigs();
+    static void                                            PrintConfigs();
 
 protected:
     Config();
@@ -31,8 +31,8 @@ protected:
 private:
     static Config*                                         instance_;
     static std::map<int, std::vector<const ServerConfig> > server_configs_;
-    static const std::map<const e_drctv_cd, std::string> createDerectiveNames();
-    static const std::map<const e_drctv_cd, std::vector<std::string> >
+    static const std::map<const EDrctvCd, std::string> createDerectiveNames();
+    static const std::map<const EDrctvCd, std::vector<std::string> >
                                           createDerectiveMap();
     static const std::vector<std::string> createAllowedMethodsVec();
     static void                           setupConfig();

--- a/src/config/ConfigParser.cpp
+++ b/src/config/ConfigParser.cpp
@@ -2,7 +2,7 @@
 
 ConfigParser* ConfigParser::instance_ = 0;
 
-ConfigParser* ConfigParser::instance() {
+ConfigParser* ConfigParser::Instance() {
     if (instance_ == 0)
         instance_ = new ConfigParser;
     return instance_;
@@ -58,8 +58,8 @@ std::vector<std::string> ConfigParser::tokenize(std::ifstream& ifs) {
     return (tokens);
 }
 
-void ConfigParser::parseConfigFile(const std::string confPath) {
-    std::ifstream            ifs(confPath);
+void ConfigParser::ParseConfigFile(const std::string conf_path) {
+    std::ifstream            ifs(conf_path);
     std::vector<std::string> tokens;
 
     if (!ifs)
@@ -67,7 +67,7 @@ void ConfigParser::parseConfigFile(const std::string confPath) {
     tokens = tokenize(ifs);
     ifs.close();
     try {
-        ConfigValidator::validateConfigFile(tokens);
+        ConfigValidator::ValidateConfigFile(tokens);
         setupConfig(tokens);
     } catch (...) { throw; }
 }
@@ -84,7 +84,7 @@ void ConfigParser::setupServerConfig(const std::vector<std::string> tokens) {
     while (it[BEGIN] != tokens.end()) {
         it[BEGIN] = std::find(it[BEGIN], tokens.end(), "{");
         it[END]   = it[BEGIN];
-        Utils::findEndBrace(++it[END]);
+        Utils::FindEndBrace(++it[END]);
 
         ServerConfig server_config = ServerConfig();
 
@@ -93,7 +93,7 @@ void ConfigParser::setupServerConfig(const std::vector<std::string> tokens) {
         setupMaxClientBodySize(it, server_config);
         setupErrorPage(it, server_config);
         setupLocationConfig(it[BEGIN], it[END], server_config);
-        Config::addServerConfig(server_config);
+        Config::AddServerConfig(server_config);
         it[BEGIN] = std::find(it[BEGIN], tokens.end(),
                               Config::DERECTIVE_NAMES.at(SRVR));
     }
@@ -107,7 +107,7 @@ void ConfigParser::setupLocationConfig(str_vec_itr begin, str_vec_itr end,
         std::string target = *++it[BEGIN];
         it[BEGIN]          = std::find(it[BEGIN], end, "{");
         it[END]            = it[BEGIN];
-        Utils::findEndBrace(++it[END]);
+        Utils::FindEndBrace(++it[END]);
 
         LocationConfig location_config = LocationConfig();
         setupTarget(target, location_config);
@@ -118,7 +118,7 @@ void ConfigParser::setupLocationConfig(str_vec_itr begin, str_vec_itr end,
         setupCgiExtensions(it, location_config);
         setupReturn(it, location_config);
 
-        server_config.setLocationConfigs(location_config);
+        server_config.SetLocationConfigs(location_config);
         it[BEGIN] = std::find(it[BEGIN], end, Config::DERECTIVE_NAMES.at(LCTN));
     }
 }
@@ -127,7 +127,7 @@ void ConfigParser::setupListen(str_vec_itr it[2], ServerConfig& server_config) {
     str_vec_itr listen =
         std::find(it[BEGIN], it[END], Config::DERECTIVE_NAMES.at(LSTN));
     if (listen != it[END])
-        server_config.setListen(std::strtol((*++listen).c_str(), NULL, 10));
+        server_config.SetListen(std::strtol((*++listen).c_str(), NULL, 10));
 }
 
 void ConfigParser::setupServerName(str_vec_itr   it[2],
@@ -135,7 +135,7 @@ void ConfigParser::setupServerName(str_vec_itr   it[2],
     str_vec_itr server_name =
         std::find(it[BEGIN], it[END], Config::DERECTIVE_NAMES.at(SRVR_NM));
     if (server_name != it[END])
-        server_config.setServerName(*++server_name);
+        server_config.SetServerName(*++server_name);
 }
 
 void ConfigParser::setupMaxClientBodySize(str_vec_itr   it[2],
@@ -143,7 +143,7 @@ void ConfigParser::setupMaxClientBodySize(str_vec_itr   it[2],
     str_vec_itr max_client_body_size = std::find(
         it[BEGIN], it[END], Config::DERECTIVE_NAMES.at(MX_CLNT_BDY_SZ));
     if (max_client_body_size != it[END])
-        server_config.setMaxClientBodySize(*++max_client_body_size);
+        server_config.SetMaxClientBodySize(*++max_client_body_size);
 }
 
 void ConfigParser::setupErrorPage(str_vec_itr   it[2],
@@ -154,14 +154,14 @@ void ConfigParser::setupErrorPage(str_vec_itr   it[2],
         error_page =
             std::find(error_page, it[END], Config::DERECTIVE_NAMES.at(ERR_PG));
         if (error_page != it[END])
-            server_config.setErrorPage(
+            server_config.SetErrorPage(
                 std::strtol((*++error_page).c_str(), NULL, 10), *++error_page);
     }
 }
 
 void ConfigParser::setupTarget(std::string     target,
                                LocationConfig& location_config) {
-    location_config.setTarget(target);
+    location_config.SetTarget(target);
 }
 
 void ConfigParser::setupAllowedMethod(str_vec_itr     it[2],
@@ -170,7 +170,7 @@ void ConfigParser::setupAllowedMethod(str_vec_itr     it[2],
         std::find(it[BEGIN], it[END], Config::DERECTIVE_NAMES.at(ALLWD_MTHD));
     if (allowed_method != it[END])
         while (*++allowed_method != ";")
-            location_config.setAllowedMethods(*allowed_method);
+            location_config.SetAllowedMethods(*allowed_method);
 }
 
 void ConfigParser::setupAlias(str_vec_itr     it[2],
@@ -178,7 +178,7 @@ void ConfigParser::setupAlias(str_vec_itr     it[2],
     str_vec_itr alias =
         std::find(it[BEGIN], it[END], Config::DERECTIVE_NAMES.at(ALIAS));
     if (alias != it[END])
-        location_config.setAlias(*++alias);
+        location_config.SetAlias(*++alias);
 }
 
 void ConfigParser::setupAutoIndex(str_vec_itr     it[2],
@@ -186,7 +186,7 @@ void ConfigParser::setupAutoIndex(str_vec_itr     it[2],
     str_vec_itr auto_index =
         std::find(it[BEGIN], it[END], Config::DERECTIVE_NAMES.at(AUTO_INDX));
     if (auto_index != it[END])
-        location_config.setAutoIndex(*++auto_index);
+        location_config.SetAutoIndex(*++auto_index);
 }
 
 void ConfigParser::setupIndex(str_vec_itr     it[2],
@@ -194,7 +194,7 @@ void ConfigParser::setupIndex(str_vec_itr     it[2],
     str_vec_itr index =
         std::find(it[BEGIN], it[END], Config::DERECTIVE_NAMES.at(INDX));
     if (index != it[END])
-        location_config.setIndex(*++index);
+        location_config.SetIndex(*++index);
 }
 
 void ConfigParser::setupCgiExtensions(str_vec_itr     it[2],
@@ -203,7 +203,7 @@ void ConfigParser::setupCgiExtensions(str_vec_itr     it[2],
         std::find(it[BEGIN], it[END], Config::DERECTIVE_NAMES.at(CGI));
     if (cgi_extensions != it[END])
         while (*++cgi_extensions != ";")
-            location_config.setCgiExtensions(*cgi_extensions);
+            location_config.SetCgiExtensions(*cgi_extensions);
 }
 
 void ConfigParser::setupReturn(str_vec_itr     it[2],
@@ -211,5 +211,5 @@ void ConfigParser::setupReturn(str_vec_itr     it[2],
     str_vec_itr rtrn =
         std::find(it[BEGIN], it[END], Config::DERECTIVE_NAMES.at(RTRN));
     if (rtrn != it[END])
-        location_config.setReturn(strtol((*++rtrn).c_str(), NULL, 10), *++rtrn);
+        location_config.SetReturn(strtol((*++rtrn).c_str(), NULL, 10), *++rtrn);
 }

--- a/src/config/ConfigParser.hpp
+++ b/src/config/ConfigParser.hpp
@@ -11,8 +11,9 @@
 
 class ConfigParser {
 public:
-    static ConfigParser* instance();
-    static void parseConfigFile(const std::string confPath = DEFAULT_CONF_PATH);
+    static ConfigParser* Instance();
+    static void
+    ParseConfigFile(const std::string conf_path = DEFAULT_CONF_PATH);
 
 protected:
     ConfigParser();

--- a/src/config/ConfigValidator.cpp
+++ b/src/config/ConfigValidator.cpp
@@ -2,7 +2,7 @@
 
 ConfigValidator* ConfigValidator::instance_ = 0;
 
-ConfigValidator* ConfigValidator::instance() {
+ConfigValidator* ConfigValidator::Instance() {
     if (instance_ == 0)
         instance_ = new ConfigValidator;
     return instance_;
@@ -21,7 +21,7 @@ ConfigValidator& ConfigValidator::operator=(const ConfigValidator& src) {
     return (*this);
 }
 
-void ConfigValidator::validateConfigFile(
+void ConfigValidator::ValidateConfigFile(
     const std::vector<std::string> tokens) {
     if (tokens.size() == 0)
         return;
@@ -74,7 +74,7 @@ void ConfigValidator::checkDerective(const std::vector<std::string> tokens,
     while (it[BEGIN] != tokens.end()) {
         it[BEGIN] = std::find(it[BEGIN], tokens.end(), "{");
         it[END]   = it[BEGIN];
-        Utils::findEndBrace(++it[END]);
+        Utils::FindEndBrace(++it[END]);
         try {
             scanDerective(it, target);
         } catch (...) { throw; }
@@ -86,7 +86,7 @@ void ConfigValidator::scanDerective(str_vec_itr       it[2],
                                     const std::string target) {
     while (++it[BEGIN] != it[END]) {
         if (*it[BEGIN] == "{")
-            Utils::findEndBrace(++it[BEGIN]);
+            Utils::FindEndBrace(++it[BEGIN]);
         if (!isValidDirectiveName(it[BEGIN], target))
             throw(std::runtime_error(ERR_MSG_INVLD_DRCTV));
         if (isDerectiveDuplicated(it[BEGIN], it[END]))
@@ -128,10 +128,10 @@ bool ConfigValidator::isDirective(str_vec_itr it) {
             Config::DELIMITERS.find(*it) == std::string::npos);
 }
 
-e_drctv_cd ConfigValidator::getDirectiveCode(std::string target) {
-    std::map<const e_drctv_cd, std::string> directive_names =
+EDrctvCd ConfigValidator::getDirectiveCode(std::string target) {
+    std::map<const EDrctvCd, std::string> directive_names =
         Config::DERECTIVE_NAMES;
-    std::map<const e_drctv_cd, std::string>::iterator it =
+    std::map<const EDrctvCd, std::string>::iterator it =
         directive_names.begin();
     while (it != Config::DERECTIVE_NAMES.end() && it->second != target)
         it++;
@@ -153,7 +153,7 @@ void ConfigValidator::checkMainDirectives(
     it[END]   = tokens.end();
     while (it[BEGIN] != it[END]) {
         if (*it[BEGIN] == "{")
-            Utils::findEndBrace(++it[BEGIN]);
+            Utils::FindEndBrace(++it[BEGIN]);
         if (*it[BEGIN] != "}" && *it[BEGIN] != Config::DERECTIVE_NAMES.at(SRVR))
             throw(std::runtime_error(ERR_MSG_INVLD_DRCTV));
         it[BEGIN]++;

--- a/src/config/ConfigValidator.hpp
+++ b/src/config/ConfigValidator.hpp
@@ -24,8 +24,8 @@
 
 class ConfigValidator {
 public:
-    static ConfigValidator* instance();
-    static void validateConfigFile(const std::vector<std::string> tokens);
+    static ConfigValidator* Instance();
+    static void ValidateConfigFile(const std::vector<std::string> tokens);
 
 protected:
     ConfigValidator();
@@ -35,27 +35,27 @@ protected:
 
 private:
     static ConfigValidator*           instance_;
-    static std::map<int, std::string> listen_server_name_map;
-    static bool isValidBraceNum(const std::vector<std::string> tokens);
-    static bool isValidBracePlace(const std::vector<std::string> tokens,
-                                  const std::string              target);
-    static bool isServerExist(const std::vector<std::string> tokens);
-    static void checkDerective(const std::vector<std::string> tokens,
-                               const std::string              target);
-    static void scanDerective(str_vec_itr it[2], const std::string target);
-    static bool isDerectiveDuplicated(str_vec_itr begin, str_vec_itr end);
-    static bool isDirective(str_vec_itr it);
-    static e_drctv_cd getDirectiveCode(std::string target);
-    static bool       isValidDirectiveName(str_vec_itr it, std::string target);
-    static void checkMainDirectives(const std::vector<std::string> tokens);
-    static bool isValidValueNum(str_vec_itr it);
-    static bool isLocationDuplicated(str_vec_itr begin, str_vec_itr end);
-    static bool isValidErrorPage(str_vec_itr begin);
-    static bool isValidAllowedMethod(str_vec_itr begin);
-    static bool isValidAutoIndex(str_vec_itr begin);
-    static bool isValidReturn(str_vec_itr begin);
-    static bool isValidListen(str_vec_itr begin);
-    static bool isDigit(const std::string& str);
+    static std::map<int, std::string> listen_server_name_map_;
+    static bool     isValidBraceNum(const std::vector<std::string> tokens);
+    static bool     isValidBracePlace(const std::vector<std::string> tokens,
+                                      const std::string              target);
+    static bool     isServerExist(const std::vector<std::string> tokens);
+    static void     checkDerective(const std::vector<std::string> tokens,
+                                   const std::string              target);
+    static void     scanDerective(str_vec_itr it[2], const std::string target);
+    static bool     isDerectiveDuplicated(str_vec_itr begin, str_vec_itr end);
+    static bool     isDirective(str_vec_itr it);
+    static EDrctvCd getDirectiveCode(std::string target);
+    static bool     isValidDirectiveName(str_vec_itr it, std::string target);
+    static void     checkMainDirectives(const std::vector<std::string> tokens);
+    static bool     isValidValueNum(str_vec_itr it);
+    static bool     isLocationDuplicated(str_vec_itr begin, str_vec_itr end);
+    static bool     isValidErrorPage(str_vec_itr begin);
+    static bool     isValidAllowedMethod(str_vec_itr begin);
+    static bool     isValidAutoIndex(str_vec_itr begin);
+    static bool     isValidReturn(str_vec_itr begin);
+    static bool     isValidListen(str_vec_itr begin);
+    static bool     isDigit(const std::string& str);
 };
 
 #endif

--- a/src/config/LocationConfig.cpp
+++ b/src/config/LocationConfig.cpp
@@ -13,7 +13,7 @@ LocationConfig& LocationConfig::operator=(const LocationConfig& src) {
     if (this != &src) {
         this->target_          = src.target_;
         this->allowed_methods_ = src.allowed_methods_;
-        this->alias_            = src.alias_;
+        this->alias_           = src.alias_;
         this->auto_index_      = src.auto_index_;
         this->index_           = src.index_;
         this->cgi_extensions_  = src.cgi_extensions_;
@@ -22,46 +22,46 @@ LocationConfig& LocationConfig::operator=(const LocationConfig& src) {
     return (*this);
 }
 
-void LocationConfig::setTarget(std::string target) { this->target_ = target; }
+void LocationConfig::SetTarget(std::string target) { this->target_ = target; }
 
-void LocationConfig::setAllowedMethods(std::string allowed_method) {
+void LocationConfig::SetAllowedMethods(std::string allowed_method) {
     this->allowed_methods_.push_back(allowed_method);
 }
 
-void LocationConfig::setAlias(std::string alias) { this->alias_ = alias; }
+void LocationConfig::SetAlias(std::string alias) { this->alias_ = alias; }
 
-void LocationConfig::setAutoIndex(std::string auto_index) {
+void LocationConfig::SetAutoIndex(std::string auto_index) {
     this->auto_index_ = auto_index == "on" ? ON : OFF;
 }
 
-void LocationConfig::setIndex(std::string index) { this->index_ = index; }
+void LocationConfig::SetIndex(std::string index) { this->index_ = index; }
 
-void LocationConfig::setCgiExtensions(std::string cgi_extension) {
+void LocationConfig::SetCgiExtensions(std::string cgi_extension) {
     this->cgi_extensions_.push_back(cgi_extension);
 }
 
-void LocationConfig::setReturn(int status_code, std::string url) {
+void LocationConfig::SetReturn(int status_code, std::string url) {
     this->return_ = std::make_pair(status_code, url);
 }
 
-std::string LocationConfig::getTarget() const { return (this->target_); }
+std::string LocationConfig::GetTarget() const { return (this->target_); }
 
-std::vector<std::string> LocationConfig::getAllowedMethods() const {
+std::vector<std::string> LocationConfig::GetAllowedMethods() const {
     return (this->allowed_methods_);
 }
 
-std::string LocationConfig::getAlias() const { return (this->alias_); }
+std::string LocationConfig::GetAlias() const { return (this->alias_); }
 
-e_auto_index_type LocationConfig::getAutoIndex() const {
+EAutoIndexType LocationConfig::GetAutoIndex() const {
     return (this->auto_index_);
 }
 
-std::string LocationConfig::getIndex() const { return (this->index_); }
+std::string LocationConfig::GetIndex() const { return (this->index_); }
 
-std::vector<std::string> LocationConfig::getCgiExtensions() const {
+std::vector<std::string> LocationConfig::GetCgiExtensions() const {
     return (this->cgi_extensions_);
 }
 
-std::pair<int, std::string> LocationConfig::getReturn() const {
+std::pair<int, std::string> LocationConfig::GetReturn() const {
     return (this->return_);
 }

--- a/src/config/LocationConfig.hpp
+++ b/src/config/LocationConfig.hpp
@@ -16,27 +16,27 @@ public:
     ~LocationConfig();
     LocationConfig& operator=(const LocationConfig& src);
 
-    void setTarget(std::string target);
-    void setAllowedMethods(std::string allowed_method);
-    void setAlias(std::string alias);
-    void setAutoIndex(std::string auto_index);
-    void setIndex(std::string index);
-    void setCgiExtensions(std::string cgi_extension);
-    void setReturn(int status_code, std::string url);
+    void SetTarget(std::string target);
+    void SetAllowedMethods(std::string allowed_method);
+    void SetAlias(std::string alias);
+    void SetAutoIndex(std::string auto_index);
+    void SetIndex(std::string index);
+    void SetCgiExtensions(std::string cgi_extension);
+    void SetReturn(int status_code, std::string url);
 
-    std::string                 getTarget() const;
-    std::vector<std::string>    getAllowedMethods() const;
-    std::string                 getAlias() const;
-    e_auto_index_type           getAutoIndex() const;
-    std::string                 getIndex() const;
-    std::vector<std::string>    getCgiExtensions() const;
-    std::pair<int, std::string> getReturn() const;
+    std::string                 GetTarget() const;
+    std::vector<std::string>    GetAllowedMethods() const;
+    std::string                 GetAlias() const;
+    EAutoIndexType              GetAutoIndex() const;
+    std::string                 GetIndex() const;
+    std::vector<std::string>    GetCgiExtensions() const;
+    std::pair<int, std::string> GetReturn() const;
 
 private:
     std::string                 target_;
     std::vector<std::string>    allowed_methods_;
     std::string                 alias_;
-    e_auto_index_type           auto_index_;
+    EAutoIndexType              auto_index_;
     std::string                 index_;
     std::vector<std::string>    cgi_extensions_;
     std::pair<int, std::string> return_;

--- a/src/config/ServerConfig.cpp
+++ b/src/config/ServerConfig.cpp
@@ -20,38 +20,38 @@ ServerConfig& ServerConfig::operator=(const ServerConfig& src) {
     return (*this);
 }
 
-void ServerConfig::setListen(int listen) { this->listen_ = listen; }
+void ServerConfig::SetListen(int listen) { this->listen_ = listen; }
 
-void ServerConfig::setServerName(std::string server_name) {
+void ServerConfig::SetServerName(std::string server_name) {
     this->server_name_ = server_name;
 }
 
-void ServerConfig::setMaxClientBodySize(std::string max_client_body_size) {
+void ServerConfig::SetMaxClientBodySize(std::string max_client_body_size) {
     this->max_client_body_size_ = max_client_body_size;
 }
 
-void ServerConfig::setErrorPage(int status_code, std::string location) {
+void ServerConfig::SetErrorPage(int status_code, std::string location) {
     this->error_page_[status_code] = location;
 }
 
-void ServerConfig::setLocationConfigs(LocationConfig& location_config) {
+void ServerConfig::SetLocationConfigs(LocationConfig& location_config) {
     this->location_configs_.insert(
-        std::make_pair(location_config.getTarget(), location_config));
+        std::make_pair(location_config.GetTarget(), location_config));
 }
 
-int ServerConfig::getListen() const { return (this->listen_); }
+int ServerConfig::GetListen() const { return (this->listen_); }
 
-std::string ServerConfig::getServerName() const { return (this->server_name_); }
+std::string ServerConfig::GetServerName() const { return (this->server_name_); }
 
-std::string ServerConfig::getMaxClientBodySize() const {
+std::string ServerConfig::GetMaxClientBodySize() const {
     return (this->max_client_body_size_);
 }
 
-std::map<int, std::string> ServerConfig::getErrorPage() const {
+std::map<int, std::string> ServerConfig::GetErrorPage() const {
     return (this->error_page_);
 }
 
 std::map<const std::string, const LocationConfig>
-ServerConfig::getLocationConfigs() const {
+ServerConfig::GetLocationConfigs() const {
     return (this->location_configs_);
 }

--- a/src/config/ServerConfig.hpp
+++ b/src/config/ServerConfig.hpp
@@ -15,18 +15,18 @@ public:
     ~ServerConfig();
     ServerConfig& operator=(const ServerConfig& src);
 
-    void setListen(int listen);
-    void setServerName(std::string serverName);
-    void setMaxClientBodySize(std::string clientMaxBodySize);
-    void setErrorPage(int status_code, std::string location);
-    void setLocationConfigs(LocationConfig& location_config);
+    void SetListen(int listen);
+    void SetServerName(std::string server_name);
+    void SetMaxClientBodySize(std::string client_max_body_size);
+    void SetErrorPage(int status_code, std::string location);
+    void SetLocationConfigs(LocationConfig& location_config);
 
-    int                        getListen() const;
-    std::string                getServerName() const;
-    std::string                getMaxClientBodySize() const;
-    std::map<int, std::string> getErrorPage() const;
+    int                        GetListen() const;
+    std::string                GetServerName() const;
+    std::string                GetMaxClientBodySize() const;
+    std::map<int, std::string> GetErrorPage() const;
     std::map<const std::string, const LocationConfig>
-    getLocationConfigs() const;
+    GetLocationConfigs() const;
 
 private:
     int                                               listen_;

--- a/src/config/Utils.cpp
+++ b/src/config/Utils.cpp
@@ -13,10 +13,10 @@ Utils& Utils::operator=(const Utils& src) {
     return (*this);
 }
 
-void Utils::findEndBrace(str_vec_itr& it) {
+void Utils::FindEndBrace(str_vec_itr& it) {
     while (*it != "}") {
         if (*it == "{")
-            findEndBrace(++it);
+            FindEndBrace(++it);
         it++;
     }
 }

--- a/src/config/Utils.hpp
+++ b/src/config/Utils.hpp
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <vector>
 
-enum e_drctv_cd {
+enum EDrctvCd {
     SRVR,
     LCTN,
     LSTN,
@@ -20,18 +20,18 @@ enum e_drctv_cd {
     MAIN,
 };
 
-enum e_pos_type {
+enum EPosType {
     BEGIN,
     END,
 };
 
-enum e_allowed_mothod_type {
+enum EAllowedMothodType {
     GET,
     POST,
     DELETE,
 };
 
-enum e_auto_index_type {
+enum EAutoIndexType {
     ON,
     OFF,
 };
@@ -46,7 +46,7 @@ public:
     ~Utils();
     Utils& operator=(const Utils& src);
 
-    static void findEndBrace(str_vec_itr& it);
+    static void FindEndBrace(str_vec_itr& it);
 };
 
 #endif

--- a/src/event/mode/ReadCGI.cpp
+++ b/src/event/mode/ReadCGI.cpp
@@ -12,7 +12,7 @@
 #include "StreamSocket.hpp"
 #include "SysError.hpp"
 
-const std::size_t ReadCGI::buf_size = 2048;
+const std::size_t ReadCGI::BUF_SIZE = 2048;
 
 ReadCGI::ReadCGI(int fd_read_from_cgi, StreamSocket stream, HTTPRequest req)
     : IOEvent(fd_read_from_cgi, READ_CGI), stream_(stream), req_(req),
@@ -27,10 +27,10 @@ ReadCGI::~ReadCGI() {
 }
 
 void ReadCGI::Run() {
-    char buf[buf_size];
+    char buf[BUF_SIZE];
     int  fd_from_cgi = polled_fd_;
 
-    int read_size = read(fd_from_cgi, buf, buf_size);
+    int read_size = read(fd_from_cgi, buf, BUF_SIZE);
     if (read_size < 0) {
         throw SysError("read", errno);
     } else if (read_size == 0) {

--- a/src/event/mode/ReadCGI.hpp
+++ b/src/event/mode/ReadCGI.hpp
@@ -18,7 +18,7 @@ public:
     virtual void     Unregister();
     virtual IOEvent* RegisterNext();
 
-    static const std::size_t buf_size;
+    static const std::size_t BUF_SIZE;
 
 private:
     ReadCGI();

--- a/src/event/mode/RecvRequest.cpp
+++ b/src/event/mode/RecvRequest.cpp
@@ -20,7 +20,7 @@
 #include <iostream>
 #include <utility>
 
-const size_t RecvRequest::buf_size = 2048;
+const size_t RecvRequest::BUF_SIZE = 2048;
 
 RecvRequest::RecvRequest()
     : IOEvent(RECV_REQUEST), stream_(StreamSocket()), req_(HTTPRequest()),
@@ -33,8 +33,8 @@ RecvRequest::RecvRequest(StreamSocket stream)
 RecvRequest::~RecvRequest() {}
 
 void RecvRequest::Run() {
-    char buf[buf_size];
-    int  recv_size = recv(stream_.GetSocketFd(), buf, buf_size, 0);
+    char buf[BUF_SIZE];
+    int  recv_size = recv(stream_.GetSocketFd(), buf, BUF_SIZE, 0);
 
     try {
         HTTPParser::update_state(state_, std::string(buf, recv_size));
@@ -110,7 +110,7 @@ const ServerConfig RecvRequest::searchServerConfig() {
     const const_iterator it_end = config_list.end();
 
     for (; it != it_end; it++) {
-        if (it->getServerName() == req_.GetHeaderValue("Host")) {
+        if (it->GetServerName() == req_.GetHeaderValue("Host")) {
             return *it;
         }
     }

--- a/src/event/mode/RecvRequest.hpp
+++ b/src/event/mode/RecvRequest.hpp
@@ -19,7 +19,7 @@ public:
     virtual void     Unregister();
     virtual IOEvent* RegisterNext();
 
-    static const std::size_t buf_size;
+    static const std::size_t BUF_SIZE;
 
 private:
     const ServerConfig searchServerConfig();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,9 +17,9 @@ int main(void) {
         EventExecutor executor;
         executor.Init();
 
-        ConfigParser::parseConfigFile("./config/google_test.conf");
-        const std::map<int, std::vector<const ServerConfig> >& server_configs =
-            Config::instance()->GetServerConfigs();
+        ConfigParser::ParseConfigFile("./config/google_test.conf");
+        std::map<int, std::vector<const ServerConfig> > server_configs =
+            Config::Instance()->GetServerConfigs();
 
         std::map<int, std::vector<const ServerConfig> >::const_iterator it_end =
             server_configs.end();

--- a/src/request/HTTPRequest.cpp
+++ b/src/request/HTTPRequest.cpp
@@ -12,9 +12,9 @@
 #include <sstream>
 #include <stdexcept>
 
-const std::string HTTPRequest::crlf = "\r\n";
+const std::string HTTPRequest::CRLF = "\r\n";
 
-const std::string::size_type HTTPRequest::crlf_size = crlf.size();
+const std::string::size_type HTTPRequest::CRLF_SIZE = CRLF.size();
 
 HTTPRequest::HTTPRequest() : status_(status::ok) {}
 

--- a/src/request/HTTPRequest.hpp
+++ b/src/request/HTTPRequest.hpp
@@ -26,8 +26,8 @@ public:
     void SetBody(const std::string);
 
     // 改行コード
-    static const std::string            crlf;
-    static const std::string::size_type crlf_size;
+    static const std::string            CRLF;
+    static const std::string::size_type CRLF_SIZE;
 
 private:
     std::string                        method_;

--- a/src/request/parse.cpp
+++ b/src/request/parse.cpp
@@ -151,7 +151,7 @@ void parse_header_line(HTTPRequest& req, const std::string& line) {
     }
 
     value = trim_space(value);
-    if (value.find_first_of(HTTPRequest::crlf) != value.npos) {
+    if (value.find_first_of(HTTPRequest::CRLF) != value.npos) {
         throw_code_badrequest("error value");
     }
 
@@ -180,13 +180,13 @@ void parse_firstline(HTTPRequest& req, const std::string& line) {
 }
 
 bool split_to_line(std::string& buf, std::string& line) {
-    std::string::size_type line_end_pos = buf.find(HTTPRequest::crlf);
+    std::string::size_type line_end_pos = buf.find(HTTPRequest::CRLF);
     if (line_end_pos == buf.npos) {
         return false;
     }
 
     line = buf.substr(0, line_end_pos);
-    buf  = buf.substr(line_end_pos + HTTPRequest::crlf_size);
+    buf  = buf.substr(line_end_pos + HTTPRequest::CRLF_SIZE);
     return true;
 }
 

--- a/src/response/HTTPResponse.cpp
+++ b/src/response/HTTPResponse.cpp
@@ -2,7 +2,7 @@
 #include "HTTPStatus.hpp"
 #include <sstream>
 
-const std::string HTTPResponse::default_version = "HTTP/1.1";
+const std::string HTTPResponse::DEFAULT_VERSION = "HTTP/1.1";
 
 std::map<int, std::string> make_status_text() {
     std::map<int, std::string> status_text;
@@ -12,10 +12,10 @@ std::map<int, std::string> make_status_text() {
     return status_text;
 }
 
-std::map<int, std::string> HTTPResponse::status_text = make_status_text();
+std::map<int, std::string> HTTPResponse::status_text_ = make_status_text();
 
 HTTPResponse::HTTPResponse()
-    : HTTPVersion_(default_version), status_code_(status::ok) {}
+    : HTTPVersion_(DEFAULT_VERSION), status_code_(status::ok) {}
 
 HTTPResponse::~HTTPResponse() {}
 
@@ -32,7 +32,7 @@ void HTTPResponse::SetStatusCode(int status) { status_code_ = status; }
 std::string HTTPResponse::ConvertToStr() const {
     std::stringstream ss;
     ss << HTTPVersion_ << " " << status_code_ << " "
-       << status_text[status_code_] << "\r\n";
+       << status_text_[status_code_] << "\r\n";
 
     for (std::map<std::string, std::string>::const_iterator it =
              headers_.begin();

--- a/src/response/HTTPResponse.hpp
+++ b/src/response/HTTPResponse.hpp
@@ -16,10 +16,10 @@ public:
 
     std::string ConvertToStr() const;
 
-    static const std::string default_version;
+    static const std::string DEFAULT_VERSION;
 
 private:
-    static std::map<int, std::string> status_text;
+    static std::map<int, std::string> status_text_;
 
     std::string                        HTTPVersion_;
     int                                status_code_;

--- a/src/uri/URI.cpp
+++ b/src/uri/URI.cpp
@@ -120,7 +120,7 @@ void URI::findLocationConfig() {
                      const LocationConfig>::const_reverse_iterator
         const_reverse_iterator;
 
-    location_map locations = server_config_.getLocationConfigs();
+    location_map locations = server_config_.GetLocationConfigs();
 
     // location configを決定する
     std::string            location_target_dir;
@@ -143,13 +143,13 @@ void URI::findLocationConfig() {
 }
 
 void URI::storeLocalPath() {
-    std::string location_target_dir = location_config_.getTarget();
+    std::string location_target_dir = location_config_.GetTarget();
     if (*location_target_dir.rbegin() != '/') {
         location_target_dir += "/";
     }
 
     // local_path_を設定する
-    std::string alias = location_config_.getAlias();
+    std::string alias = location_config_.GetAlias();
     if (*alias.rbegin() != '/') {
         alias += "/";
     }

--- a/test/config.cpp
+++ b/test/config.cpp
@@ -5,11 +5,11 @@
 const std::string CONF_PATH = "./config/error";
 
 void testParseConfigError(std::string file_path, std::string expect) {
-    EXPECT_ANY_THROW(ConfigParser::parseConfigFile(file_path));
+    EXPECT_ANY_THROW(ConfigParser::ParseConfigFile(file_path));
 
     testing::internal::CaptureStderr();
     try {
-        ConfigParser::parseConfigFile(file_path);
+        ConfigParser::ParseConfigFile(file_path);
     } catch (const std::exception& e) { std::cerr << e.what(); }
 
     std::string actual = testing::internal::GetCapturedStderr();

--- a/test/uri_test.cpp
+++ b/test/uri_test.cpp
@@ -15,8 +15,8 @@ protected:
     virtual void SetUp() {
         typedef std::map<int, std::vector<const ServerConfig> > configs_map;
 
-        ConfigParser::parseConfigFile("./config/google_test.conf");
-        configs_map servers_map = Config::instance()->GetServerConfigs();
+        ConfigParser::ParseConfigFile("./config/google_test.conf");
+        configs_map servers_map = Config::Instance()->GetServerConfigs();
 
         configs_map::const_iterator it = servers_map.begin();
 


### PR DESCRIPTION
## やったこと
- config部分にclang-tidyをかける
`clang-tidy` に追記部分
```clang-tidy
 - key:             readability-identifier-naming.ClassConstantCase
    value:           UPPER_CASE
- key:             readability-identifier-naming.ClassMemberSuffix
    value:           _
```
それぞれの説明はリンク参照

[ClassConstantCase](https://clang.llvm.org/extra/clang-tidy/checks/readability-identifier-naming.html#cmdoption-arg-classconstantcase) 

[ClassMemberSuffix](https://clang.llvm.org/extra/clang-tidy/checks/readability-identifier-naming.html#cmdoption-arg-classmembersuffixl)

定数は基本的に`UPPER_CASE`でpublicなメソッドは`CamelCase`(先頭大文字)、privateなメソッドは`camelCase`(先頭小文字)です。

## やらないこと

- 特になし

## 動作確認
make tidy (clang-tidy )実行時
```
Error while processing /Users/nakahodojunya/42/lvl_05/webserv/src/socket/ListeningSocket.cpp.
/usr/local/Cellar/llvm/13.0.1_1/bin/../include/c++/v1/map:726:17: error: object of type 'std::__value_type<const std::string, const LocationConfig>::__nc_ref_pair_type' (aka 'pair<const std::string &, const LocationConfig &>') cannot be assigned because its copy assignment operator is implicitly deleted [clang-diagnostic-error]
        __ref() = __v.__get_value();
                ^
/usr/local/Cellar/llvm/13.0.1_1/bin/../include/c++/v1/__tree:1662:39: note: in instantiation of member function 'std::__value_type<const std::string, const LocationConfig>::operator=' requested here
            __cache.__get()->__value_ = *__first;
                                      ^
/usr/local/Cellar/llvm/13.0.1_1/bin/../include/c++/v1/__tree:1619:9: note: in instantiation of function template specialization 'std::__tree<std::__value_type<const std::string, const LocationConfig>, std::__map_value_compare<const std::string, std::__value_type<const std::string, const LocationConfig>, std::less<const std::string>, true>, std::allocator<std::__value_type<const std::string, const LocationConfig>>>::__assign_multi<std::__tree_const_iterator<std::__value_type<const std::string, const LocationConfig>, std::__tree_node<std::__value_type<const std::string, const LocationConfig>, void *> *, long>>' requested here
        __assign_multi(__t.begin(), __t.end());
        ^
/usr/local/Cellar/llvm/13.0.1_1/bin/../include/c++/v1/map:1041:21: note: in instantiation of member function 'std::__tree<std::__value_type<const std::string, const LocationConfig>, std::__map_value_compare<const std::string, std::__value_type<const std::string, const LocationConfig>, std::less<const std::string>, true>, std::allocator<std::__value_type<const std::string, const LocationConfig>>>::operator=' requested here
            __tree_ = __m.__tree_;
                    ^
/Users/nakahodojunya/42/lvl_05/webserv/src/config/ServerConfig.cpp:18:37: note: in instantiation of member function 'std::map<const std::string, const LocationConfig>::operator=' requested here
        this->location_configs_     = src.location_configs_;
                                    ^
/usr/local/Cellar/llvm/13.0.1_1/bin/../include/c++/v1/__utility/pair.h:55:5: note: copy assignment operator is implicitly deleted because 'pair<const std::string &, const LocationConfig &>' has a user-declared move constructor
    pair(pair&&) = default;
    ^
Found compiler error(s).
make: *** [tidy] Error 1
```
このようなエラーが出ました。

`ServerConfig.cpp`
```cpp
this->location_configs_     = src.location_configs_;
```
該当箇所をコメントアウトしたらエラーは無くなりましたが、webservの挙動がおかしくなったのでエラーのままにしています。コンパイルは問題なくエラー無しでできます。

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

## issues

about : #85 
close #85 
