### PR TITLE
:bug: Read系のIOEventでEOF判定ができるように修正

### DIFF
--- a/src/cgi/CGIResponseParser.hpp
+++ b/src/cgi/CGIResponseParser.hpp
@@ -13,7 +13,7 @@ public:
 
     CGIResponseParser(CGIResponse& resp);
     ~CGIResponseParser();
-    void operator()(std::string new_buf, ssize_t read_size);
+    void operator()(std::string new_buf, ssize_t read_size, intptr_t offset);
 
     const Phase&       GetPhase() const { return phase_; }
     const std::string& GetLeftBuf() const { return left_buf_; }

--- a/src/event/EventExecutor.cpp
+++ b/src/event/EventExecutor.cpp
@@ -65,7 +65,7 @@ void EventExecutor::onEvent(std::vector<struct kevent> event_vec,
         }
 
         try {
-            doEvent(event);
+            doEvent(event, event_vec[i].data);
             nextEvent(event);
         } catch (std::pair<StreamSocket, status::code> err) {
             errorNextEvent(event, new SendError(err.first, err.second));
@@ -73,7 +73,9 @@ void EventExecutor::onEvent(std::vector<struct kevent> event_vec,
     }
 }
 
-void EventExecutor::doEvent(IOEvent* event) { event->Run(); }
+void EventExecutor::doEvent(IOEvent* event, intptr_t offset) {
+    event->Run(offset);
+}
 
 void EventExecutor::nextEvent(IOEvent* event) {
     IOEvent* next_event = event->RegisterNext();

--- a/src/event/EventExecutor.hpp
+++ b/src/event/EventExecutor.hpp
@@ -18,7 +18,7 @@ public:
 
 private:
     void onEvent(std::vector<struct kevent> event_vec, int event_size);
-    void doEvent(IOEvent* event);
+    void doEvent(IOEvent* event, intptr_t offset);
     void nextEvent(IOEvent* event);
     void errorNextEvent(IOEvent* prev, IOEvent* next);
 

--- a/src/event/IOEvent.hpp
+++ b/src/event/IOEvent.hpp
@@ -2,6 +2,8 @@
 #define IOEVENT_HPP
 
 #include <sys/event.h>
+
+#define UNUSED(x) ((void)(x))
 class IOEvent {
 public:
     enum IOEventMode {

--- a/src/event/IOEvent.hpp
+++ b/src/event/IOEvent.hpp
@@ -1,6 +1,7 @@
 #ifndef IOEVENT_HPP
 #define IOEVENT_HPP
 
+#include <sys/event.h>
 class IOEvent {
 public:
     enum IOEventMode {
@@ -20,10 +21,10 @@ public:
     IOEvent(int fd, IOEventMode mode) : polled_fd_(fd), mode_(mode) {}
     virtual ~IOEvent() {}
 
-    virtual void     Run()          = 0;
-    virtual void     Register()     = 0;
-    virtual void     Unregister()   = 0;
-    virtual IOEvent* RegisterNext() = 0;
+    virtual void     Run(intptr_t offset) = 0;
+    virtual void     Register()           = 0;
+    virtual void     Unregister()         = 0;
+    virtual IOEvent* RegisterNext()       = 0;
 
     void SetPolledFd(int fd) { polled_fd_ = fd; }
     int  GetPolledFd() { return polled_fd_; }

--- a/src/event/mode/AcceptConn.cpp
+++ b/src/event/mode/AcceptConn.cpp
@@ -17,7 +17,7 @@ AcceptConn::AcceptConn(ListeningSocket listener)
 AcceptConn::~AcceptConn() {}
 
 void AcceptConn::Run(intptr_t offset) {
-    (void)offset;
+    UNUSED(offset);
     struct sockaddr_in peer_sin;
     int                len, stream_fd;
 

--- a/src/event/mode/AcceptConn.cpp
+++ b/src/event/mode/AcceptConn.cpp
@@ -16,7 +16,8 @@ AcceptConn::AcceptConn(ListeningSocket listener)
 
 AcceptConn::~AcceptConn() {}
 
-void AcceptConn::Run() {
+void AcceptConn::Run(intptr_t offset) {
+    (void)offset;
     struct sockaddr_in peer_sin;
     int                len, stream_fd;
 

--- a/src/event/mode/AcceptConn.hpp
+++ b/src/event/mode/AcceptConn.hpp
@@ -12,7 +12,7 @@ public:
 
     ListeningSocket& GetListeningSocket() { return listener_; }
 
-    virtual void     Run();
+    virtual void     Run(intptr_t offset);
     virtual void     Register();
     virtual void     Unregister();
     virtual IOEvent* RegisterNext();

--- a/src/event/mode/ReadCGI.cpp
+++ b/src/event/mode/ReadCGI.cpp
@@ -31,7 +31,7 @@ ReadCGI::~ReadCGI() {
     }
 }
 
-void ReadCGI::Run() {
+void ReadCGI::Run(intptr_t offset) {
     char buf[BUF_SIZE];
     int  fd_from_cgi = polled_fd_;
 
@@ -41,7 +41,7 @@ void ReadCGI::Run() {
     }
 
     try {
-        cgi_parser_(std::string(buf, read_size), read_size);
+        cgi_parser_(std::string(buf, read_size), read_size, offset);
     } catch (status::code code) { throw std::make_pair(stream_, code); }
 }
 void ReadCGI::Register() { EventRegister::Instance().AddReadEvent(this); }

--- a/src/event/mode/ReadCGI.hpp
+++ b/src/event/mode/ReadCGI.hpp
@@ -15,7 +15,7 @@ public:
     ReadCGI(int fd_read_from_cgi, StreamSocket stream, HTTPRequest req);
     virtual ~ReadCGI();
 
-    virtual void     Run();
+    virtual void     Run(intptr_t offset);
     virtual void     Register();
     virtual void     Unregister();
     virtual IOEvent* RegisterNext();
@@ -27,9 +27,9 @@ private:
 
 private:
     // ReadCGIに必要な入力
-    StreamSocket      stream_;
-    HTTPRequest       req_;
-    bool              is_finish_;
+    StreamSocket stream_;
+    HTTPRequest  req_;
+    bool         is_finish_;
     CGIResponse  cgi_resp_;
 
     // ReadCGIによってできる出力
@@ -37,7 +37,7 @@ private:
     // ReadCGIに必要な入力
     CGIResponseParser cgi_parser_;
     // ReadCGIによってできる出力
-    std::string  cgi_output_;
+    std::string cgi_output_;
 };
 
 #endif

--- a/src/event/mode/ReadFile.hpp
+++ b/src/event/mode/ReadFile.hpp
@@ -13,7 +13,7 @@ public:
     ReadFile(StreamSocket stream, int fd);
     virtual ~ReadFile();
 
-    virtual void     Run();
+    virtual void     Run(intptr_t offset);
     virtual void     Register();
     virtual void     Unregister();
     virtual IOEvent* RegisterNext();
@@ -25,6 +25,7 @@ private:
     // ReadFile に必要な入力
     StreamSocket stream_;
     HTTPRequest  req_;
+    bool         finish_;
 
     // ReadFile によってできる出力
     std::string  file_content_;

--- a/src/event/mode/RecvRequest.cpp
+++ b/src/event/mode/RecvRequest.cpp
@@ -38,12 +38,12 @@ RecvRequest::RecvRequest(StreamSocket stream)
 RecvRequest::~RecvRequest() {}
 
 void RecvRequest::Run(intptr_t offset) {
+    UNUSED(offset);
     char buf[BUF_SIZE];
     int  recv_size = recv(stream_.GetSocketFd(), buf, BUF_SIZE, 0);
 
     try {
-        HTTPParser::update_state(state_, std::string(buf, recv_size), recv_size,
-                                 offset);
+        HTTPParser::update_state(state_, std::string(buf, recv_size));
     } catch (status::code code) {
         throw std::make_pair(stream_, code);
         // EventExecutor::onEventでcatch

--- a/src/event/mode/RecvRequest.cpp
+++ b/src/event/mode/RecvRequest.cpp
@@ -37,12 +37,13 @@ RecvRequest::RecvRequest(StreamSocket stream)
 
 RecvRequest::~RecvRequest() {}
 
-void RecvRequest::Run() {
+void RecvRequest::Run(intptr_t offset) {
     char buf[BUF_SIZE];
     int  recv_size = recv(stream_.GetSocketFd(), buf, BUF_SIZE, 0);
 
     try {
-        HTTPParser::update_state(state_, std::string(buf, recv_size));
+        HTTPParser::update_state(state_, std::string(buf, recv_size), recv_size,
+                                 offset);
     } catch (status::code code) {
         throw std::make_pair(stream_, code);
         // EventExecutor::onEventでcatch

--- a/src/event/mode/RecvRequest.hpp
+++ b/src/event/mode/RecvRequest.hpp
@@ -15,7 +15,7 @@ public:
     RecvRequest(StreamSocket stream);
     virtual ~RecvRequest();
 
-    virtual void     Run();
+    virtual void     Run(intptr_t offset);
     virtual void     Register();
     virtual void     Unregister();
     virtual IOEvent* RegisterNext();

--- a/src/event/mode/SendError.cpp
+++ b/src/event/mode/SendError.cpp
@@ -8,7 +8,7 @@ SendError::SendError(StreamSocket& stream, status::code code)
 
 SendError::~SendError() {}
 
-void SendError::Run() {}
+void SendError::Run(intptr_t offset) { (void)offset; }
 
 void SendError::Register() {}
 

--- a/src/event/mode/SendError.cpp
+++ b/src/event/mode/SendError.cpp
@@ -8,7 +8,7 @@ SendError::SendError(StreamSocket& stream, status::code code)
 
 SendError::~SendError() {}
 
-void SendError::Run(intptr_t offset) { (void)offset; }
+void SendError::Run(intptr_t offset) { UNUSED(offset); }
 
 void SendError::Register() {}
 

--- a/src/event/mode/SendError.hpp
+++ b/src/event/mode/SendError.hpp
@@ -10,7 +10,7 @@ public:
     SendError(StreamSocket& stream, status::code);
     virtual ~SendError();
 
-    virtual void     Run();
+    virtual void     Run(intptr_t offset);
     virtual void     Register();
     virtual void     Unregister();
     virtual IOEvent* RegisterNext();

--- a/src/event/mode/SendResponse.cpp
+++ b/src/event/mode/SendResponse.cpp
@@ -25,7 +25,8 @@ SendResponse::~SendResponse() {
     }
 }
 
-void SendResponse::Run() {
+void SendResponse::Run(intptr_t offset) {
+    (void)offset;
     int ret = send(stream_.GetSocketFd(), all_buf_.c_str(), all_buf_.size(), 0);
     if (ret < 0) {
         throw SysError("send", errno);

--- a/src/event/mode/SendResponse.cpp
+++ b/src/event/mode/SendResponse.cpp
@@ -26,7 +26,7 @@ SendResponse::~SendResponse() {
 }
 
 void SendResponse::Run(intptr_t offset) {
-    (void)offset;
+    UNUSED(offset);
     int ret = send(stream_.GetSocketFd(), all_buf_.c_str(), all_buf_.size(), 0);
     if (ret < 0) {
         throw SysError("send", errno);

--- a/src/event/mode/SendResponse.hpp
+++ b/src/event/mode/SendResponse.hpp
@@ -11,7 +11,7 @@ public:
     SendResponse(StreamSocket stream, std::string buf);
     virtual ~SendResponse();
 
-    virtual void     Run();
+    virtual void     Run(intptr_t offset);
     virtual void     Register();
     virtual void     Unregister();
     virtual IOEvent* RegisterNext();

--- a/src/event/mode/WriteCGI.cpp
+++ b/src/event/mode/WriteCGI.cpp
@@ -26,7 +26,8 @@ WriteCGI::~WriteCGI() {
     }
 }
 
-void WriteCGI::Run() {
+void WriteCGI::Run(intptr_t offset) {
+    (void)offset;
     int fd_write_to_cgi = polled_fd_;
     int write_size =
         write(fd_write_to_cgi, req_.GetBody().c_str(), req_.GetBody().size());

--- a/src/event/mode/WriteCGI.cpp
+++ b/src/event/mode/WriteCGI.cpp
@@ -27,7 +27,7 @@ WriteCGI::~WriteCGI() {
 }
 
 void WriteCGI::Run(intptr_t offset) {
-    (void)offset;
+    UNUSED(offset);
     int fd_write_to_cgi = polled_fd_;
     int write_size =
         write(fd_write_to_cgi, req_.GetBody().c_str(), req_.GetBody().size());

--- a/src/event/mode/WriteCGI.hpp
+++ b/src/event/mode/WriteCGI.hpp
@@ -11,7 +11,7 @@ public:
     WriteCGI(class CGI cgi, StreamSocket stream, HTTPRequest req);
     virtual ~WriteCGI();
 
-    virtual void     Run();
+    virtual void     Run(intptr_t offset);
     virtual void     Register();
     virtual void     Unregister();
     virtual IOEvent* RegisterNext();

--- a/src/event/mode/WriteFile.cpp
+++ b/src/event/mode/WriteFile.cpp
@@ -16,7 +16,7 @@ WriteFile::~WriteFile() {
 }
 
 void WriteFile::Run(intptr_t offset) {
-    (void)offset;
+    UNUSED(offset);
     std::string content = req_.GetBody();
     int         size    = write(polled_fd_, content.c_str(), content.size());
     if (size < 0 || static_cast<size_t>(size) != content.size())

--- a/src/event/mode/WriteFile.cpp
+++ b/src/event/mode/WriteFile.cpp
@@ -15,9 +15,10 @@ WriteFile::~WriteFile() {
     }
 }
 
-void WriteFile::Run() {
+void WriteFile::Run(intptr_t offset) {
+    (void)offset;
     std::string content = req_.GetBody();
-    int         size     = write(polled_fd_, content.c_str(), content.size());
+    int         size    = write(polled_fd_, content.c_str(), content.size());
     if (size < 0 || static_cast<size_t>(size) != content.size())
         throw SysError("write", errno);
 }

--- a/src/event/mode/WriteFile.hpp
+++ b/src/event/mode/WriteFile.hpp
@@ -15,7 +15,7 @@ public:
     WriteFile(StreamSocket stream, int fd, HTTPRequest req);
     virtual ~WriteFile();
 
-    virtual void     Run();
+    virtual void     Run(intptr_t offset);
     virtual void     Register();
     virtual void     Unregister();
     virtual IOEvent* RegisterNext();

--- a/src/request/HTTPParser.cpp
+++ b/src/request/HTTPParser.cpp
@@ -13,7 +13,7 @@ SendBadrequest::SendBadrequest() {}
 
 SendBadrequest::~SendBadrequest() {}
 
-void SendBadrequest::Run(intptr_t offset) { (void)offset; }
+void SendBadrequest::Run(intptr_t offset) { UNUSED(offset); }
 
 // TODO: 要相談
 // parse関数内でthrowするときにstreamをsetするのがめんどい

--- a/src/request/HTTPParser.cpp
+++ b/src/request/HTTPParser.cpp
@@ -13,7 +13,7 @@ SendBadrequest::SendBadrequest() {}
 
 SendBadrequest::~SendBadrequest() {}
 
-void SendBadrequest::Run() {}
+void SendBadrequest::Run(intptr_t offset) { (void)offset; }
 
 // TODO: 要相談
 // parse関数内でthrowするときにstreamをsetするのがめんどい

--- a/src/request/HTTPParser.hpp
+++ b/src/request/HTTPParser.hpp
@@ -6,6 +6,7 @@
 #include "URI.hpp"
 #include "mode/SendResponse.hpp"
 #include <string>
+#include <sys/event.h>
 
 namespace HTTPParser {
 enum Phase { FIRST_LINE, HEADER_LINE, BODY, DONE };
@@ -24,7 +25,7 @@ public:
     SendBadrequest(StreamSocket stream);
     virtual ~SendBadrequest();
 
-    virtual void     Run();
+    virtual void     Run(intptr_t offset);
     virtual IOEvent* RegisterNext();
 };
 
@@ -44,7 +45,8 @@ private:
     HTTPRequest& req_;
 };
 
-void update_state(State& state, const std::string buf);
+void update_state(State& state, const std::string buf, int recv_size,
+                  intptr_t offset);
 
 void validate_request(const URI& uri, const HTTPRequest& req);
 

--- a/src/request/HTTPParser.hpp
+++ b/src/request/HTTPParser.hpp
@@ -45,8 +45,7 @@ private:
     HTTPRequest& req_;
 };
 
-void update_state(State& state, const std::string buf, int recv_size,
-                  intptr_t offset);
+void update_state(State& state, const std::string buf);
 
 void validate_request(const URI& uri, const HTTPRequest& req);
 

--- a/src/request/parse.cpp
+++ b/src/request/parse.cpp
@@ -340,10 +340,7 @@ void validate_request(const URI& uri, const HTTPRequest& req) {
     validate_allowed_method(uri, req.GetMethod());
 }
 
-void update_state(State& state, const std::string new_buf, int recv_size,
-                  intptr_t offset) {
-    (void)recv_size;
-    (void)offset;
+void update_state(State& state, const std::string new_buf) {
     HTTPRequest& req   = state.Request();
     std::string& buf   = state.Buf();
     Phase&       phase = state.Phase();

--- a/src/request/parse.cpp
+++ b/src/request/parse.cpp
@@ -340,7 +340,10 @@ void validate_request(const URI& uri, const HTTPRequest& req) {
     validate_allowed_method(uri, req.GetMethod());
 }
 
-void update_state(State& state, const std::string new_buf) {
+void update_state(State& state, const std::string new_buf, int recv_size,
+                  intptr_t offset) {
+    (void)recv_size;
+    (void)offset;
     HTTPRequest& req   = state.Request();
     std::string& buf   = state.Buf();
     Phase&       phase = state.Phase();

--- a/test/cgi_response_parser_test.cpp
+++ b/test/cgi_response_parser_test.cpp
@@ -10,7 +10,7 @@ TEST(CGIResponseParser, SplitLine) {
     CGIResponse       resp;
     CGIResponseParser parser(resp);
 
-    parser(msg, msg.size());
-    parser("",  0);
+    parser(msg, msg.size(), msg.size());
+    parser("",  0, 0);
     EXPECT_EQ("text/html", resp.GetHeaderValue("content-type"));
 }

--- a/test/httpparser.cpp
+++ b/test/httpparser.cpp
@@ -14,7 +14,7 @@ TEST(HTTPParser, ParseAllAtOnce) {
     string      message("GET index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
     HTTPRequest req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message, message.size(), message.size());
+    HTTPParser::update_state(state, message);
 
     EXPECT_EQ("GET", req.GetMethod());
     EXPECT_EQ("index.html", req.GetRequestTarget());
@@ -27,7 +27,7 @@ TEST(HTTPParser, EmptyVersion) {
     string            message("GET index.html \r\nHost: localhost\r\n\r\n");
     HTTPRequest       req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message, message.size(), message.size());
+    HTTPParser::update_state(state, message);
 
     EXPECT_EQ("GET", req.GetMethod());
     EXPECT_EQ("index.html", req.GetRequestTarget());
@@ -41,7 +41,7 @@ TEST(HTTPParser, ParseBody) {
                              "4\r\n\r\nhoge");
     HTTPRequest req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message, message.size(), message.size());
+    HTTPParser::update_state(state, message);
 
     EXPECT_EQ("POST", req.GetMethod());
     EXPECT_EQ("hoge", req.GetBody());
@@ -63,7 +63,7 @@ TEST(HTTPParser, ChunkedBody) {
 
     HTTPRequest       req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message, message.size(), message.size());
+    HTTPParser::update_state(state, message);
 
     EXPECT_EQ("Mozilla"
               "Developer"
@@ -84,7 +84,7 @@ TEST(HTTPParser, ChunkedBodyIncludeLastChunk) {
 
     HTTPRequest       req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message, message.size(), message.size());
+    HTTPParser::update_state(state, message);
 
     EXPECT_EQ("0\r\n\r\n", req.GetBody());
     EXPECT_EQ(HTTPParser::DONE, state.Phase());
@@ -98,7 +98,7 @@ TEST(HTTPParser, ParsePart1) {
     HTTPRequest       req;
     HTTPParser::State state(req);
     for (vector<string>::iterator it = m.begin(); it != m.end(); it++) {
-        HTTPParser::update_state(state, *it, it->size(), it->size());
+        HTTPParser::update_state(state, *it);
     }
 
     EXPECT_EQ("GET", req.GetMethod());
@@ -117,7 +117,7 @@ TEST(HTTPParser, ParsePart2) {
     HTTPRequest       req;
     HTTPParser::State state(req);
     for (vector<string>::iterator it = m.begin(); it != m.end(); it++) {
-        HTTPParser::update_state(state, *it, it->size(), it->size());
+        HTTPParser::update_state(state, *it);
     }
 
     EXPECT_EQ("GET", req.GetMethod());
@@ -131,7 +131,7 @@ TEST(HTTPParser, HeaderValueTrimSpace) {
     string      message("GET / HTTP/1.1\r\nHost:    localhost   \r\n\r\n");
     HTTPRequest req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message, message.size(), message.size());
+    HTTPParser::update_state(state, message);
 
     EXPECT_EQ("localhost", req.GetHeaderValue("host"));
 }
@@ -140,7 +140,7 @@ TEST(HTTPParser, NormalizeHeaderKey) {
     string            message("GET / HTTP/1.1\r\nHOST:localhost\r\n\r\n");
     HTTPRequest       req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message, message.size(), message.size());
+    HTTPParser::update_state(state, message);
 
     EXPECT_EQ("localhost", req.GetHeaderValue("host"));
 }
@@ -149,7 +149,7 @@ TEST(HTTPParser, PhaseFirstLine) {
     string            message("GET / ");
     HTTPRequest       req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message, message.size(), message.size());
+    HTTPParser::update_state(state, message);
 
     EXPECT_EQ(HTTPParser::FIRST_LINE, state.Phase());
 }
@@ -158,7 +158,7 @@ TEST(HTTPParser, PhaseHeaderLine) {
     string            message("GET / HTTP/1.1\r\nHost:localhost\r\n");
     HTTPRequest       req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message, message.size(), message.size());
+    HTTPParser::update_state(state, message);
 
     EXPECT_EQ(HTTPParser::HEADER_LINE, state.Phase());
 }
@@ -172,8 +172,7 @@ TEST(HTTPParser, EmptyMethod) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -186,8 +185,7 @@ TEST(HTTPParser, LowercaseMethod) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -200,8 +198,7 @@ TEST(HTTPParser, VersionNotExistName) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -214,8 +211,7 @@ TEST(HTTPParser, VersionLowerCase) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -228,8 +224,7 @@ TEST(HTTPParser, VersionMultipleDot) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -242,8 +237,7 @@ TEST(HTTPParser, VersionEndWithDot) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -256,8 +250,7 @@ TEST(HTTPParser, VersionStartWithDot) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -270,8 +263,7 @@ TEST(HTTPParser, VersionOnlyName) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -284,8 +276,7 @@ TEST(HTTPParser, VersionNotExistSlash) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -298,8 +289,7 @@ TEST(HTTPParser, VersionNotExistdot) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -312,8 +302,7 @@ TEST(HTTPParser, NoHost) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -326,8 +315,7 @@ TEST(HTTPParser, ValueContainCR) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -340,8 +328,7 @@ TEST(HTTPParser, ValueContainLF) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -354,8 +341,7 @@ TEST(HTTPParser, KeyIncludeSpace) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -368,8 +354,7 @@ TEST(HTTPParser, EmptyKey) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -393,8 +378,7 @@ TEST(HTTPParser, ChunkedBodyNotCRLFAfterSize) {
     HTTPRequest       req;
     HTTPParser::State state(req);
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) { EXPECT_EQ(status::bad_request, code); }
 }
 
@@ -415,8 +399,7 @@ TEST(HTTPParser, ChunkedBodyNotCRLFAfterData) {
     HTTPRequest       req;
     HTTPParser::State state(req);
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) { EXPECT_EQ(status::bad_request, code); }
 }
 
@@ -429,8 +412,7 @@ TEST(HTTPParser, VersionNotSupported) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) {
         //
         EXPECT_EQ(status::version_not_suppoted, code);
@@ -455,8 +437,7 @@ TEST(HTTPParser, UnsupportedMediaType) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message, message.size(),
-                                 message.size());
+        HTTPParser::update_state(state, message);
     } catch (status::code code) {
         //
         EXPECT_EQ(status::unsupported_media_type, code);

--- a/test/httpparser.cpp
+++ b/test/httpparser.cpp
@@ -14,7 +14,7 @@ TEST(HTTPParser, ParseAllAtOnce) {
     string      message("GET index.html HTTP/1.1\r\nHost: localhost\r\n\r\n");
     HTTPRequest req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message);
+    HTTPParser::update_state(state, message, message.size(), message.size());
 
     EXPECT_EQ("GET", req.GetMethod());
     EXPECT_EQ("index.html", req.GetRequestTarget());
@@ -27,7 +27,7 @@ TEST(HTTPParser, EmptyVersion) {
     string            message("GET index.html \r\nHost: localhost\r\n\r\n");
     HTTPRequest       req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message);
+    HTTPParser::update_state(state, message, message.size(), message.size());
 
     EXPECT_EQ("GET", req.GetMethod());
     EXPECT_EQ("index.html", req.GetRequestTarget());
@@ -41,7 +41,7 @@ TEST(HTTPParser, ParseBody) {
                              "4\r\n\r\nhoge");
     HTTPRequest req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message);
+    HTTPParser::update_state(state, message, message.size(), message.size());
 
     EXPECT_EQ("POST", req.GetMethod());
     EXPECT_EQ("hoge", req.GetBody());
@@ -63,7 +63,7 @@ TEST(HTTPParser, ChunkedBody) {
 
     HTTPRequest       req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message);
+    HTTPParser::update_state(state, message, message.size(), message.size());
 
     EXPECT_EQ("Mozilla"
               "Developer"
@@ -84,7 +84,7 @@ TEST(HTTPParser, ChunkedBodyIncludeLastChunk) {
 
     HTTPRequest       req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message);
+    HTTPParser::update_state(state, message, message.size(), message.size());
 
     EXPECT_EQ("0\r\n\r\n", req.GetBody());
     EXPECT_EQ(HTTPParser::DONE, state.Phase());
@@ -98,7 +98,7 @@ TEST(HTTPParser, ParsePart1) {
     HTTPRequest       req;
     HTTPParser::State state(req);
     for (vector<string>::iterator it = m.begin(); it != m.end(); it++) {
-        HTTPParser::update_state(state, *it);
+        HTTPParser::update_state(state, *it, it->size(), it->size());
     }
 
     EXPECT_EQ("GET", req.GetMethod());
@@ -117,7 +117,7 @@ TEST(HTTPParser, ParsePart2) {
     HTTPRequest       req;
     HTTPParser::State state(req);
     for (vector<string>::iterator it = m.begin(); it != m.end(); it++) {
-        HTTPParser::update_state(state, *it);
+        HTTPParser::update_state(state, *it, it->size(), it->size());
     }
 
     EXPECT_EQ("GET", req.GetMethod());
@@ -131,7 +131,7 @@ TEST(HTTPParser, HeaderValueTrimSpace) {
     string      message("GET / HTTP/1.1\r\nHost:    localhost   \r\n\r\n");
     HTTPRequest req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message);
+    HTTPParser::update_state(state, message, message.size(), message.size());
 
     EXPECT_EQ("localhost", req.GetHeaderValue("host"));
 }
@@ -140,7 +140,7 @@ TEST(HTTPParser, NormalizeHeaderKey) {
     string            message("GET / HTTP/1.1\r\nHOST:localhost\r\n\r\n");
     HTTPRequest       req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message);
+    HTTPParser::update_state(state, message, message.size(), message.size());
 
     EXPECT_EQ("localhost", req.GetHeaderValue("host"));
 }
@@ -149,7 +149,7 @@ TEST(HTTPParser, PhaseFirstLine) {
     string            message("GET / ");
     HTTPRequest       req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message);
+    HTTPParser::update_state(state, message, message.size(), message.size());
 
     EXPECT_EQ(HTTPParser::FIRST_LINE, state.Phase());
 }
@@ -158,7 +158,7 @@ TEST(HTTPParser, PhaseHeaderLine) {
     string            message("GET / HTTP/1.1\r\nHost:localhost\r\n");
     HTTPRequest       req;
     HTTPParser::State state(req);
-    HTTPParser::update_state(state, message);
+    HTTPParser::update_state(state, message, message.size(), message.size());
 
     EXPECT_EQ(HTTPParser::HEADER_LINE, state.Phase());
 }
@@ -172,7 +172,8 @@ TEST(HTTPParser, EmptyMethod) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -185,7 +186,8 @@ TEST(HTTPParser, LowercaseMethod) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -198,7 +200,8 @@ TEST(HTTPParser, VersionNotExistName) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -211,7 +214,8 @@ TEST(HTTPParser, VersionLowerCase) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -224,7 +228,8 @@ TEST(HTTPParser, VersionMultipleDot) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -237,7 +242,8 @@ TEST(HTTPParser, VersionEndWithDot) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -250,7 +256,8 @@ TEST(HTTPParser, VersionStartWithDot) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -263,7 +270,8 @@ TEST(HTTPParser, VersionOnlyName) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -276,7 +284,8 @@ TEST(HTTPParser, VersionNotExistSlash) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -289,7 +298,8 @@ TEST(HTTPParser, VersionNotExistdot) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -302,7 +312,8 @@ TEST(HTTPParser, NoHost) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -315,7 +326,8 @@ TEST(HTTPParser, ValueContainCR) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -328,7 +340,8 @@ TEST(HTTPParser, ValueContainLF) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -341,7 +354,8 @@ TEST(HTTPParser, KeyIncludeSpace) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -354,7 +368,8 @@ TEST(HTTPParser, EmptyKey) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) {
         //
         EXPECT_EQ(status::bad_request, code);
@@ -378,7 +393,8 @@ TEST(HTTPParser, ChunkedBodyNotCRLFAfterSize) {
     HTTPRequest       req;
     HTTPParser::State state(req);
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) { EXPECT_EQ(status::bad_request, code); }
 }
 
@@ -399,7 +415,8 @@ TEST(HTTPParser, ChunkedBodyNotCRLFAfterData) {
     HTTPRequest       req;
     HTTPParser::State state(req);
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) { EXPECT_EQ(status::bad_request, code); }
 }
 
@@ -412,7 +429,8 @@ TEST(HTTPParser, VersionNotSupported) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) {
         //
         EXPECT_EQ(status::version_not_suppoted, code);
@@ -437,7 +455,8 @@ TEST(HTTPParser, UnsupportedMediaType) {
     HTTPParser::State state(req);
 
     try {
-        HTTPParser::update_state(state, message);
+        HTTPParser::update_state(state, message, message.size(),
+                                 message.size());
     } catch (status::code code) {
         //
         EXPECT_EQ(status::unsupported_media_type, code);


### PR DESCRIPTION
## やったこと

- Read系のIOEventでEOF判定ができなかったのを修正
- `IOEvent::Run()`関数を`IOEvent::Run(intptr_t)`に変更
- 引数の合わなくなったテスト関数の引数を修正

**EventExecutor.cpp**
```cpp
void EventExecutor::onEvent(std::vector<struct kevent> event_vec,
                            int                        event_size) {
    ...
        try {
            doEvent(event, event_vec[i].data); // keventのdataを第二引数に渡す
            nextEvent(event);
        } catch (std::pair<StreamSocket, status::code> err) {
            errorNextEvent(event, new SendError(err.first, err.second));
        }
    }
}

void EventExecutor::doEvent(IOEvent* event, intptr_t offset) {
    event->Run(offset); // Runはoffsetを引数に通る
}
```
**IOEventを継承したRead系の具象クラス**
**ReadFile.cpp** 
```cpp
void ReadFile::Run(intptr_t offset) {
    char buf[BUF_SIZE];

    int read_size = read(fd, buf, BUF_SIZE);

    if (read_size == 0 || read_size == offset) { // read_size が0の時と、read_sizeとoffsetが一致した時にイベント終了のフラグを立てる
        finish_ = true;
    }
    file_content_.append(buf, read_size);

}
```
**ReadCGI.cpp**
```cpp
void ReadCGI::Run(intptr_t offset) {
    char buf[BUF_SIZE];

    int read_size = read(fd_from_cgi, buf, BUF_SIZE);

    try {
        cgi_parser_(std::string(buf, read_size), read_size, offset); // cgi_parser内で終了判定をする
    } catch (status::code code) { throw std::make_pair(stream_, code); }
}
```
**RecvRequest.cpp**
```cpp
void RecvRequest::Run(intptr_t offset) {
    char buf[BUF_SIZE];
    int  recv_size = recv(stream_.GetSocketFd(), buf, BUF_SIZE, 0);

    try {
        HTTPParser::update_state(state_, std::string(buf, recv_size), recv_size, // update_state内で終了判定する
                                 offset);
    } catch (status::code code) {
    }
}
```
Read系のイベントの場合、`offset`は読み込み可能なバイト数を表す。したがって`read_size`と一致した時、全て読み込んだことになります。
Write系のIOEventは`offset`は`void型`にキャストしただけで、利用していません

**BUF_SIZEが10** で **22バイトのファイル**を読み込む時
```
// 1回目
read_size = 10
offset = 22
// 2回目
read_size = 10
offset = 12
// 3回目
read_size = 2
offset  = 2
// 読み込み完了
```

## やらないこと

- update_state()関数内では終了判定追加していないので、すどうさん対応お願いします:pray:

## 動作確認

- 動作は変わらず、テストもgo-testとgoogletestともにパスしています！

## その他

- 終了判定よくわからないところあれば聞いてください

## issues

about : #114 