### PR TITLE
引数にerrorのconfigを取りwebservを実行しようとするスクリプト作成

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,16 @@ tidy-fix: ## Run clang-tidy --fix
 debug: CXXFLAGS += -fsanitize=address -D WS_DEBUG=1
 debug: re ## Debug mode rebuild
 
+################# test script ####################
+
+TESTDIR= ./test
+.PHONY: lsof
+lsof: ## Run lsof.sh
+	@bash $(TESTDIR)/lsof.sh
+
+.PHONY: error_conf
+error_conf: ## Run error_conf.sh
+	@bash $(TESTDIR)/error_conf.sh
 
 ################# google test ####################
 

--- a/test/error_conf.sh
+++ b/test/error_conf.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+GREEN="\033[32m"
+RESET="\033[0m"
+ALIVE_TIME=1
+EXECUTE_FILE="./webserv"
+
+execute() {
+  LOG="${2}.log"
+  rm -f ${LOG}
+  (${EXECUTE_FILE} ${1} 2>${LOG}) & sleep ${ALIVE_TIME}
+
+  if [ -s ${LOG} ]; then
+    echo -e "${GREEN}[[ ${2} ]]${RESET}\nOK\n"
+  else
+    echo -e "${GREEN}[[ ${2} ]]${RESET}\nNG\n"
+  fi
+}
+
+
+# config/error/内のファイルでwebservを実行
+error_configs=`find ./config/error -type f`
+for filepath in ${error_configs}; do
+  NAME=`basename ${filepath}`
+  execute ${filepath} ${NAME} & sleep 0.1
+done
+
+execute "no_such_file.conf" "no_such_file"
+wait
+killall ${EXECUTE_FILE} 2>/dev/null
+
+# ログをlog.txtに写す
+logfile="log.txt"
+rm -f ${logfile}
+for filepath in ${error_configs}; do
+  NAME=`basename ${filepath}`
+  LOG="${NAME}.log"
+  echo -e "[[ ${LOG} ]]" >> log.txt
+  cat $LOG >> log.txt
+  echo >> log.txt
+  rm $LOG
+done
+
+echo -e "[[ no_such_file.log ]]" >> log.txt
+cat no_such_file.log >> log.txt
+echo >> log.txt


### PR DESCRIPTION
## やったこと

- test/error_conf.shを作成
  - `config/error/`配下のファイルを引数にwebservを実行して、エラーが吐かれているか確認
  - 存在しないファイルを引数にwebservを実行してエラーが吐かれているか確認
  - 結果をlog.txtに出力

## 動作確認

`make error_conf`で実行

```
❯ make error_conf
[[ unexpected_token_01.conf ]]
OK

[[ invalid_directive_02.conf ]]
OK

[[ invalid_return.conf ]]
OK

[[ duplicated_directive.conf ]]
OK

[[ invalid_value_num.conf ]]
OK

[[ invalid_auto_index.conf ]]
OK

[[ invalid_allowed_method.conf ]]
OK

[[ invalid_error_page.conf ]]
OK

[[ invalid_brace_num.conf ]]
OK

[[ invalid_directive_01.conf ]]
OK

[[ invalid_listen.conf ]]
OK

[[ duplicated_location.conf ]]
OK

[[ unexpected_token_02.conf ]]
OK

[[ no_such_file ]]
OK

❯ cat log.txt
[[ unexpected_token_01.conf.log ]]
unexpected token

[[ invalid_directive_02.conf.log ]]
invalid derective

[[ invalid_return.conf.log ]]
invalid return

[[ duplicated_directive.conf.log ]]
duplicated derective

[[ invalid_value_num.conf.log ]]
invalid value num

[[ invalid_auto_index.conf.log ]]
invalid auto index

[[ invalid_allowed_method.conf.log ]]
invalid allowed method

[[ invalid_error_page.conf.log ]]
invalid error page

[[ invalid_brace_num.conf.log ]]
invalid number of braces

[[ invalid_directive_01.conf.log ]]
invalid derective

[[ invalid_listen.conf.log ]]
invalid listen

[[ duplicated_location.conf.log ]]
duplicated location

[[ unexpected_token_02.conf.log ]]
unexpected token

[[ no_such_file.log ]]
invalid file

```

## その他

- cub3dの時に作ったスクリプトを流用しました。
