### PR TITLE
🐛 CGIが無限ループしていたのを修正

### DIFF
--- a/src/cgi/CGI.cpp
+++ b/src/cgi/CGI.cpp
@@ -95,8 +95,7 @@ std::vector<std::string> CGI::makeArgs() {
     // 実行するスクリプトファイルのパス設定
     // スクリプトファイルをvalidateする
     const struct stat s = URI::Stat(uri_.GetLocalPath());
-    if (S_ISDIR(s.st_mode) ||
-        access(uri_.GetLocalPath().c_str(), (R_OK | X_OK)) < 0) {
+    if (S_ISDIR(s.st_mode) || !(s.st_mode & S_IRUSR)) {
         throw status::forbidden;
     }
 

--- a/src/cgi/CGI.cpp
+++ b/src/cgi/CGI.cpp
@@ -12,6 +12,7 @@
 
 #include "ExecveArray.hpp"
 #include "HTTPRequest.hpp"
+#include "HTTPStatus.hpp"
 #include "SysError.hpp"
 #include "URI.hpp"
 
@@ -92,6 +93,13 @@ std::vector<std::string> CGI::makeArgs() {
     // command設定
     args.push_back(COMMANDS.find(uri_.GetExtension())->second);
     // 実行するスクリプトファイルのパス設定
+    // スクリプトファイルをvalidateする
+    const struct stat s = URI::Stat(uri_.GetLocalPath());
+    if (S_ISDIR(s.st_mode) ||
+        access(uri_.GetLocalPath().c_str(), (R_OK | X_OK)) < 0) {
+        throw status::forbidden;
+    }
+
     args.push_back(uri_.GetLocalPath());
     // 残りの引数設定
     args.insert(args.end(), uri_.GetArgs().begin(), uri_.GetArgs().end());

--- a/src/cgi/CGIResponseParser.cpp
+++ b/src/cgi/CGIResponseParser.cpp
@@ -224,7 +224,7 @@ bool CGIResponseParser::isClientRedirDocumentResponse(
         }
     }
 
-    std::string absoluteURL = cgi_resp.GetHeaderValue("location");
+    std::string absolute_url = cgi_resp.GetHeaderValue("location");
     // TODO absoluteURLをvalidate
 
     return true;


### PR DESCRIPTION
## やったこと

- CGIスクリプトがディレクトリの場合や読み込み権限がない場合に無限ループしていた問題を修正

## やらないこと

- 次やるべきこと(新たなissue)があれば記載

## 動作確認

- cgiスクリプトがディレクトリや読み込み権限がない場合は403を返す

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

## issues

about : #123 

close #123 
