### PR TITLE
Fix/auto_index

### DIFF
--- a/src/event/mode/Get.cpp
+++ b/src/event/mode/Get.cpp
@@ -156,6 +156,7 @@ void Get::prepareSendResponse(std::string content) {
     resp.AppendHeader("Content-Length", size.str());
     resp.AppendHeader("Content-Type", "text/html; charset=utf-8");
     resp.SetBody(content);
+    resp.PrintInfo();
     next_event_ = new SendResponse(stream_, resp.ConvertToStr());
 }
 

--- a/src/event/mode/Get.cpp
+++ b/src/event/mode/Get.cpp
@@ -58,9 +58,7 @@ Get::~Get() {}
 void Get::Run() {
     printLogStart();
 
-    std::string                 local_path = uri_.GetLocalPath();
-    std::string                 index      = location_config_.GetIndex();
-    std::pair<int, std::string> redir      = location_config_.GetReturn();
+    std::pair<int, std::string> redir = location_config_.GetReturn();
 
     // redirect
     if (hasRedir(redir, uri_.GetRawTarget(), location_config_.GetTarget())) {
@@ -68,24 +66,26 @@ void Get::Run() {
         return;
     }
 
-    const struct stat s = URI::Stat(local_path);
+    const struct stat s = URI::Stat(uri_.GetLocalPath());
     if (S_ISDIR(s.st_mode)) {
-        processDir(index, local_path);
+        processDir();
     } else {
-        prepareReadFile(local_path);
+        prepareReadFile(uri_.GetLocalPath());
     }
     printLogEnd();
 }
 
 IOEvent* Get::NextEvent() { return next_event_; }
 
-void Get::processDir(std::string index, std::string local_path) {
+void Get::processDir() {
+    std::string local_path = uri_.GetLocalPath();
+    std::string index      = location_config_.GetIndex();
     complementSlash(local_path);
 
     if (hasIndex(index)) {
-        processIndex(local_path + index, local_path);
+        processIndex(local_path + index);
     } else {
-        tryAutoIndex(local_path);
+        tryAutoIndex();
     }
 }
 
@@ -111,17 +111,17 @@ void Get::processRedir(std::pair<int, std::string> redir) {
     next_event_ = new SendResponse(stream_, resp.ConvertToStr());
 }
 
-void Get::processIndex(std::string fullpath, std::string local_path) {
+void Get::processIndex(std::string fullpath) {
     if (existFile(fullpath)) {
         prepareReadFile(fullpath);
     } else {
-        tryAutoIndex(local_path);
+        tryAutoIndex();
     }
 }
 
-void Get::tryAutoIndex(std::string local_path) {
+void Get::tryAutoIndex() {
     if (location_config_.GetAutoIndex() == ON) {
-        autoIndex(local_path);
+        autoIndex();
     } else {
         printLogNotFound();
         throw status::not_found;
@@ -238,17 +238,21 @@ std::string Get::fileSize(struct stat* s) {
 
 std::string Get::fileInfo(struct dirent* ent, std::string path) {
     complementSlash(path);
-    const std::string fullpath = "." + path + std::string(ent->d_name);
-    struct stat       s        = URI::Stat(fullpath);
+    const std::string fullpath = path + std::string(ent->d_name);
+
+    struct stat s = URI::Stat(fullpath);
 
     return timeStamp(&s.st_mtime) + fileSize(&s);
 }
 
-void Get::autoIndex(std::string path) {
+void Get::autoIndex() {
     printLogAutoIndex();
 
+    const std::string& local_path  = uri_.GetLocalPath();
+    const std::string& decode_path = uri_.GetDecodePath();
+
     errno    = 0;
-    DIR* dir = opendir(path.c_str());
+    DIR* dir = opendir(local_path.c_str());
     if (dir == NULL) {
         perror("opendir");
         if (errno == EACCES) {
@@ -258,11 +262,10 @@ void Get::autoIndex(std::string path) {
     }
 
     // "."を削除
-    path = path.substr(1);
     std::stringstream ss;
     ss << "<html>" << CRLF << "<head>" << CRLF << "<title>"
-       << "Index of " << path << "</title>" << CRLF << "</head>" << CRLF
-       << "<body>" << CRLF << "<h1> Index of " << path << "</h1>" << CRLF
+       << "Index of " << decode_path << "</title>" << CRLF << "</head>" << CRLF
+       << "<body>" << CRLF << "<h1> Index of " << decode_path << "</h1>" << CRLF
        << "<hr>" << CRLF << "<pre>" << CRLF;
 
     for (struct dirent* ent = readdir(dir); ent != NULL; ent = readdir(dir)) {
@@ -270,9 +273,9 @@ void Get::autoIndex(std::string path) {
             continue;
         }
 
-        ss << aElement(ent, path);
+        ss << aElement(ent, decode_path);
         if (std::string("..") != ent->d_name) {
-            ss << fileInfo(ent, path);
+            ss << fileInfo(ent, uri_.GetLocalPath());
         }
         ss << CRLF;
     }

--- a/src/event/mode/Get.hpp
+++ b/src/event/mode/Get.hpp
@@ -4,6 +4,7 @@
 #include "IOEvent.hpp"
 #include "StreamSocket.hpp"
 #include "URI.hpp"
+#include <dirent.h>
 
 class Get {
 public:
@@ -35,6 +36,7 @@ private:
     std::string spaces(std::string name, int n);
     std::string timeStamp(time_t* time);
     std::string fileSize(struct stat* s);
+    std::string generateAutoIndexHTML(DIR* dir);
 
     // log
     void printLogStart();

--- a/src/event/mode/Get.hpp
+++ b/src/event/mode/Get.hpp
@@ -16,19 +16,20 @@ public:
     static const std::string CRLF;
 
 private:
-    void processDir(std::string index, std::string path);
+    void processDir();
     void processRedir(std::pair<int, std::string> redir);
-    void processIndex(std::string fullpath, std::string location_path);
-    void tryAutoIndex(std::string path);
+    void processIndex(std::string fullpath);
+    void tryAutoIndex();
     void prepareReadFile(std::string path);
     void prepareSendResponse(std::string content);
     bool existFile(std::string path);
-    bool hasRedir(std::pair<int, std::string> redir, std::string path, std::string target);
+    bool hasRedir(std::pair<int, std::string> redir, std::string path,
+                  std::string target);
     bool hasIndex(std::string index);
     void complementSlash(std::string& path);
 
     // autoindex
-    void        autoIndex(std::string path);
+    void        autoIndex();
     std::string aElement(struct dirent* ent, std::string path);
     std::string fileInfo(struct dirent* ent, std::string path);
     std::string spaces(std::string name, int n);


### PR DESCRIPTION
## やったこと

- auto indexがバグっていたのを修正

auto index処理のpathは全てlocal pathで扱っていたので、下のようなconfigで`/auto_index/`にアクセス時、aタグ部分をクリックしたときに、`./docs/~`がターゲットのリクエストが送られてしまっていた。
```
location /auto_index/ {
    alias ./docs/;
    auto_index on;
}
```

内部的な`stat`の引数等はlocal pathを使用して、HTML生成時にはdecode pathを使用するようにした。

--- 
- Getクラスリファクタ
  - Getクラスの`uri_`から取得できる値はなるべくprivateメソッドの引数に渡さないようにした。
  - auto indexのHTML生成部分を別メソッドに切り出した。
## 動作確認

- ブラウザで挙動確認

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

## issues

about : #140 
close #140
