### PR TITLE
RecvRequest::PrepareResponse()のリファクタ

### DIFF
--- a/src/event/mode/Get.cpp
+++ b/src/event/mode/Get.cpp
@@ -1,7 +1,9 @@
 #include "Get.hpp"
+#include "CGI.hpp"
 #include "HTTPResponse.hpp"
 #include "HTTPStatus.hpp"
 #include "LocationConfig.hpp"
+#include "ReadCGI.hpp"
 #include "ReadFile.hpp"
 #include "SendResponse.hpp"
 #include "URI.hpp"
@@ -19,8 +21,9 @@
 
 const std::string Get::CRLF = "\r\n";
 
-Get::Get(StreamSocket stream, URI& uri)
-    : stream_(stream), uri_(uri), location_config_(uri_.GetLocationConfig()) {}
+Get::Get(StreamSocket stream, URI& uri, const HTTPRequest& req)
+    : stream_(stream), uri_(uri), req_(req),
+      location_config_(uri_.GetLocationConfig()) {}
 
 Get::~Get() {}
 
@@ -62,12 +65,21 @@ void Get::Run() {
     std::string                 index      = location_config_.GetIndex();
     std::pair<int, std::string> redir      = location_config_.GetReturn();
 
+    // CGI
+    if (CGI::IsCGI(uri_, "GET")) {
+        class CGI cgi(uri_, req_);
+        cgi.Run();
+        next_event_ = new ReadCGI(cgi.FdForReadFromCGI(), stream_, req_);
+        return;
+    }
+
     // redirect
     if (hasRedir(redir, uri_.GetRawTarget(), location_config_.GetTarget())) {
         processRedir(redir);
         return;
     }
 
+    // Index or AutoIndex
     const struct stat s = URI::Stat(local_path);
     if (S_ISDIR(s.st_mode)) {
         processDir(index, local_path);
@@ -77,7 +89,10 @@ void Get::Run() {
     printLogEnd();
 }
 
-IOEvent* Get::NextEvent() { return next_event_; }
+IOEvent* Get::NextEvent() {
+    next_event_->Register();
+    return next_event_;
+}
 
 void Get::processDir(std::string index, std::string local_path) {
     complementSlash(local_path);

--- a/src/event/mode/Get.hpp
+++ b/src/event/mode/Get.hpp
@@ -1,13 +1,14 @@
 #ifndef GET_HPP
 #define GET_HPP
 
+#include "HTTPRequest.hpp"
 #include "IOEvent.hpp"
 #include "StreamSocket.hpp"
 #include "URI.hpp"
 
 class Get {
 public:
-    Get(StreamSocket stream, URI& uri);
+    Get(StreamSocket stream, URI& uri, const HTTPRequest& req);
     ~Get();
 
     void     Run();
@@ -23,7 +24,8 @@ private:
     void prepareReadFile(std::string path);
     void prepareSendResponse(std::string content);
     bool existFile(std::string path);
-    bool hasRedir(std::pair<int, std::string> redir, std::string path, std::string target);
+    bool hasRedir(std::pair<int, std::string> redir, std::string path,
+                  std::string target);
     bool hasIndex(std::string index);
     void complementSlash(std::string& path);
 
@@ -45,6 +47,7 @@ private:
     StreamSocket          stream_;
     IOEvent*              next_event_;
     URI&                  uri_;
+    const HTTPRequest&    req_;
     const LocationConfig& location_config_;
 };
 

--- a/src/event/mode/Post.cpp
+++ b/src/event/mode/Post.cpp
@@ -1,31 +1,47 @@
 #include "Post.hpp"
+#include "CGI.hpp"
+#include "WriteCGI.hpp"
 #include <iostream>
 
 Post::Post(StreamSocket stream, HTTPRequest req, URI& uri)
-    : stream_(stream), uri_(uri), req_(req) {}
+    : stream_(stream), uri_(uri), req_(req), write_event_(NULL),
+      is_cgi_(false) {}
 
 Post::~Post() {}
 
 void Post::Run() {
-    std::string base_path = uri_.GetLocationConfig().GetUploadPath();
-    if (base_path.substr(base_path.length() - 1) != "/")
-        base_path += "/";
-    std::string        file_name = generateFileName();
-    std::string        file_path = base_path + file_name;
-    const struct stat& stat_buf  = uri_.Stat(base_path);
+    if (CGI::IsCGI(uri_, "POST")) {
+        is_cgi_ = true;
+        class CGI cgi(uri_, req_);
+        cgi.Run();
+        fd_read_from_cgi_ = cgi.FdForReadFromCGI();
+        write_fd_         = cgi.FdForWriteToCGI();
+    } else {
+        std::string base_path = uri_.GetLocationConfig().GetUploadPath();
+        if (base_path.substr(base_path.length() - 1) != "/")
+            base_path += "/";
+        std::string        file_name = generateFileName();
+        std::string        file_path = base_path + file_name;
+        const struct stat& stat_buf  = uri_.Stat(base_path);
 
-    if ((stat_buf.st_mode & S_IRWXU) != S_IRWXU)
-        throw status::forbidden;
-    fd_ = open(file_path.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_NONBLOCK,
-               0644);
-    if (fd_ < 0)
-        throw status::server_error;
+        if ((stat_buf.st_mode & S_IRWXU) != S_IRWXU)
+            throw status::forbidden;
+        write_fd_ = open(file_path.c_str(),
+                         O_WRONLY | O_CREAT | O_TRUNC | O_NONBLOCK, 0644);
+        if (write_fd_ < 0)
+            throw status::server_error;
+    }
 }
 
 IOEvent* Post::RegisterNext() {
-    IOEvent* write_file = new WriteFile(stream_, fd_, req_);
-    write_file->Register();
-    return (write_file);
+    if (is_cgi_) {
+        write_event_ =
+            new WriteCGI(write_fd_, fd_read_from_cgi_, stream_, req_);
+    } else {
+        write_event_ = new WriteFile(stream_, write_fd_, req_);
+    }
+    write_event_->Register();
+    return (write_event_);
 }
 
 std::string Post::generateFileName() {

--- a/src/event/mode/Post.hpp
+++ b/src/event/mode/Post.hpp
@@ -31,7 +31,10 @@ private:
     StreamSocket stream_;
     URI&         uri_;
     HTTPRequest  req_;
-    int          fd_;
+    IOEvent*     write_event_;
+    bool         is_cgi_;
+    int          fd_read_from_cgi_;
+    int          write_fd_;
     std::string  generateFileName();
 };
 

--- a/src/event/mode/RecvRequest.cpp
+++ b/src/event/mode/RecvRequest.cpp
@@ -94,8 +94,7 @@ IOEvent* RecvRequest::PrepareResponse(const HTTPRequest&  req,
         Post post(stream, req, uri);
         post.Run();
         return post.RegisterNext();
-    }
-    if (req.GetMethod() == "DELETE") {
+    } else if (req.GetMethod() == "DELETE") {
         Delete dlt(stream, uri);
         dlt.Run();
         return dlt.RegisterNext();

--- a/src/event/mode/WriteCGI.cpp
+++ b/src/event/mode/WriteCGI.cpp
@@ -14,9 +14,11 @@
 
 #include <iostream>
 
-WriteCGI::WriteCGI(class CGI cgi, StreamSocket stream, HTTPRequest req)
-    : IOEvent(cgi.FdForWriteToCGI(), WRITE_CGI), cgi_(cgi), stream_(stream),
-      req_(req) {}
+WriteCGI::WriteCGI(int fd_for_write_to_cgi, int fd_for_read_form_cgi,
+                   StreamSocket stream, HTTPRequest req)
+    : IOEvent(fd_for_write_to_cgi, WRITE_CGI),
+      fd_for_write_to_cgi_(fd_for_write_to_cgi),
+      fd_for_read_form_cgi_(fd_for_read_form_cgi), stream_(stream), req_(req) {}
 
 WriteCGI::~WriteCGI() {}
 
@@ -38,7 +40,7 @@ void WriteCGI::Unregister() { EventRegister::Instance().DelWriteEvent(this); }
 IOEvent* WriteCGI::RegisterNext() {
     Unregister();
 
-    IOEvent* read_cgi = new ReadCGI(cgi_.FdForReadFromCGI(), stream_, req_);
+    IOEvent* read_cgi = new ReadCGI(fd_for_read_form_cgi_, stream_, req_);
     read_cgi->Register();
     return read_cgi;
 }

--- a/src/event/mode/WriteCGI.hpp
+++ b/src/event/mode/WriteCGI.hpp
@@ -8,7 +8,8 @@
 
 class WriteCGI : public IOEvent {
 public:
-    WriteCGI(class CGI cgi, StreamSocket stream, HTTPRequest req);
+    WriteCGI(int fd_for_write_to_cgi, int fd_for_read_form_cgi,
+             StreamSocket stream, HTTPRequest req);
     virtual ~WriteCGI();
 
     virtual void     Run(intptr_t offset);
@@ -21,7 +22,8 @@ private:
     WriteCGI();
 
 private:
-    class CGI    cgi_;
+    int          fd_for_write_to_cgi_;
+    int          fd_for_read_form_cgi_;
     StreamSocket stream_;
     HTTPRequest  req_;
 };


### PR DESCRIPTION
## やったこと
- メソッドの条件分岐が冗長だったので、CGIの判定箇所をメソッドのクラス内に含めました。

## やらないこと

- 次やるべきこと(新たなissue)があれば記載

## 動作確認

- 動作は変わりません

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

## issues

about : #143 

See Also: #119 

close #143
