### PR TITLE
:bug: 同時接続2以上siegeを動かすとwebservへアクセスできなくなる

### DIFF
--- a/src/event/EventRegister.cpp
+++ b/src/event/EventRegister.cpp
@@ -13,21 +13,6 @@ std::vector<struct kevent>& EventRegister::RegisteredEvents() {
     return registered_events_;
 }
 
-bool EventRegister::AddAcceptEvent(IOEvent* event) {
-    if (event == NULL) {
-        return false;
-    }
-
-    if (event->GetIOEventMode() == IOEvent::ACCEPT_CONNECTION) {
-        struct kevent ev;
-        EV_SET(&ev, event->GetPolledFd(), EVFILT_READ,
-               EV_ADD | EV_ENABLE | EV_CLEAR, 0, 0, (void*)event);
-        registered_events_.push_back(ev);
-        return true;
-    }
-    return false;
-}
-
 bool EventRegister::AddReadEvent(IOEvent* event) {
     if (!event) {
         return false;

--- a/src/event/EventRegister.hpp
+++ b/src/event/EventRegister.hpp
@@ -16,7 +16,6 @@ public:
     std::vector<struct kevent>& RegisteredEvents();
 
     // Add I/O event
-    bool AddAcceptEvent(IOEvent* event);
     bool AddReadEvent(IOEvent* event);
     bool AddWriteEvent(IOEvent* event);
 

--- a/src/event/mode/AcceptConn.cpp
+++ b/src/event/mode/AcceptConn.cpp
@@ -34,7 +34,7 @@ void AcceptConn::Run(intptr_t offset) {
     printLog();
 }
 
-void AcceptConn::Register() { EventRegister::Instance().AddAcceptEvent(this); }
+void AcceptConn::Register() { EventRegister::Instance().AddReadEvent(this); }
 
 void AcceptConn::Unregister() { EventRegister::Instance().DelReadEvent(this); }
 


### PR DESCRIPTION
## やったこと
`AddAcceptEvent`の`EV_SET`マクロの第四引数に`EV_CLEAR`が設定されていたため、接続ができなくなっていた。
したがって`AddAcceptEvent`を削除し、`AddReadEvent`で`AcceptConnection`を登録できるよう変更しました。

## やらないこと

- 次やるべきこと(新たなissue)があれば記載

## 動作確認
```cpp
$ ./webserv ./config/default.conf 
```
別ターミナルで
```cpp
$ siege -c 100 -t 10s -b http://localhost:4242/
```
`siege -c 100 -t 10s -b http://localhost:4242/`を複数回実行

**実行結果**
```bash
HTTP/1.1 200     0.15 secs:     170 bytes ==> GET  /
HTTP/1.1 200     0.15 secs:     170 bytes ==> GET  /

Lifting the server siege...
Transactions:                   5847 hits
Availability:                 100.00 %
Elapsed time:                   9.08 secs
Data transferred:               0.95 MB
Response time:                  0.15 secs
Transaction rate:             643.94 trans/sec
Throughput:                     0.10 MB/sec
Concurrency:                   99.13
Successful transactions:        5847
Failed transactions:               0
Longest transaction:            0.23
Shortest transaction:           0.02
```

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

## issues

About: #146

close #146 
