### PR TITLE
Fix/get empty file

### DIFF
--- a/src/event/mode/Get.cpp
+++ b/src/event/mode/Get.cpp
@@ -178,6 +178,11 @@ void Get::prepareSendResponse(std::string content) {
 void Get::prepareReadFile(std::string path) {
     printLogReadFile();
 
+    if (URI::Stat(path).st_size == 0) {
+        prepareEmptySendResponse();
+        return;
+    }
+
     int fd = open(path.c_str(), O_RDONLY | O_NONBLOCK);
     if (fd == -1) {
         perror("open");
@@ -187,6 +192,13 @@ void Get::prepareReadFile(std::string path) {
         throw status::server_error;
     }
     next_event_ = new ReadFile(stream_, fd);
+}
+
+void Get::prepareEmptySendResponse() {
+    HTTPResponse resp;
+
+    resp.AppendHeader("Content-Length", "0");
+    next_event_ = new SendResponse(stream_, resp.ConvertToStr());
 }
 
 // ####### autoindexの実装 ########

--- a/src/event/mode/Get.cpp
+++ b/src/event/mode/Get.cpp
@@ -178,6 +178,7 @@ void Get::prepareSendResponse(std::string content) {
 void Get::prepareReadFile(std::string path) {
     printLogReadFile();
 
+    // size0のファイルはイベントで通知されないため、ReadFileイベントは作らない
     if (URI::Stat(path).st_size == 0) {
         prepareEmptySendResponse();
         return;
@@ -198,6 +199,7 @@ void Get::prepareEmptySendResponse() {
     HTTPResponse resp;
 
     resp.AppendHeader("Content-Length", "0");
+    resp.PrintInfo();
     next_event_ = new SendResponse(stream_, resp.ConvertToStr());
 }
 

--- a/src/event/mode/Get.hpp
+++ b/src/event/mode/Get.hpp
@@ -24,6 +24,7 @@ private:
     void tryAutoIndex();
     void prepareReadFile(std::string path);
     void prepareSendResponse(std::string content);
+    void prepareEmptySendResponse();
     bool existFile(std::string path);
     bool hasRedir(std::pair<int, std::string> redir, std::string path,
                   std::string target);

--- a/src/event/mode/ReadFile.cpp
+++ b/src/event/mode/ReadFile.cpp
@@ -32,8 +32,7 @@ void ReadFile::Run(intptr_t offset) {
     char buf[BUF_SIZE];
     int  fd = polled_fd_;
 
-    int read_size = read(fd, buf, BUF_SIZE);
-    // TODO: エラー処理
+    ssize_t read_size = read(fd, buf, BUF_SIZE);
     if (read_size == -1) {
         perror("read");
         throw status::server_error;
@@ -69,7 +68,6 @@ IOEvent* ReadFile::RegisterNext() {
     printLogEnd();
     return send_response;
 }
-
 
 int ReadFile::Close() {
     if (polled_fd_ == -1) {


### PR DESCRIPTION
## やったこと

空ファイルをGETしようとしたときにレスポンスが返らないバグを修正
- keventはサイズが0のファイルをreadするイベントを登録しても通知しないようでした。(read_sizeが0になることはなく、最後まで読み切った時点で終了という挙動と整合性はあると思いました。)
- openの前に`URI::Stat`でファイルサイズを確認して、０の場合はopenせずにSendResponseを準備するようにしました。
- empty.html作成

## 動作確認

```
❯ curl -v localhost:4242/html/empty.html
*   Trying 127.0.0.1:4242...
* Connected to localhost (127.0.0.1) port 4242 (#0)
> GET /html/empty.html HTTP/1.1
> Host: localhost:4242
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Length: 0
<
* Connection #0 to host localhost left intact

```

## issues

about : #147 

close #147 
