### PR TITLE
:bug: SendError内のRecvRequest::SearchServerConfigの例外を拾う

### DIFF
--- a/src/event/mode/SendError.cpp
+++ b/src/event/mode/SendError.cpp
@@ -21,16 +21,15 @@ void SendError::Register() {}
 void SendError::Unregister() {}
 
 IOEvent* SendError::RegisterNext() {
-    ServerConfig server_config =
-        RecvRequest::SearchServerConfig(stream_.GetRequest(), stream_);
-    std::string error_page = server_config.GetErrorPage()[status_code_];
-
-    if (!existErrorPage(error_page)) {
-        return sendResponse();
-    }
-
     // エラーが起きた場合、sendResponseでデフォルトページを返す
     try {
+        ServerConfig server_config =
+            RecvRequest::SearchServerConfig(stream_.GetRequest(), stream_);
+        std::string error_page = server_config.GetErrorPage()[status_code_];
+
+        if (!existErrorPage(error_page)) {
+            return sendResponse();
+        }
         // エラーページのpathからlocal pathを取得
         URI uri(server_config, error_page);
         uri.Init();


### PR DESCRIPTION
## やったこと

- SendError内のRecvRequest::SearchServerConfigをtryスコープの中に記述

telnetでPOST時サーバーが落ちていたのは、
1. `Content-Length`がないため、`HTTPParser::update_state`で`status::badrequest`が投げられる
2. `Executor::onEvent`で`SendError`が作成される
3. `SendError::NextEvent`で`RecvRequest::SearchServerConfig`が呼ばれる
4. Hostが空なので、`getaddrinfo`がエラーを吐き、`status::server_error`が投げられる
5. uncaught exception

という流れでした。
4で投げられた例外をcatchするようにしました。

## やらないこと
getaddrinfoのエラー処理

## 動作確認

```
❯ telnet localhost 4242
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
POST / HTTP/1.1

HTTP/1.1 400 Bad Request
Content-Length: 158
Content-Type: text/html; charset=utf-8

<html>
<head><title>400 Bad Request</title></head>
<body>
<center><h1>400 Bad Request</h1></center>
<hr><center>webserv/1.0.0</center>
</body>
</html>
Connection closed by foreign host.
```

## issues

about : #157 

see also : #156

close #157 
