### PR TITLE
Feature/status501

### DIFF
--- a/config/go_test.conf
+++ b/config/go_test.conf
@@ -3,6 +3,7 @@ server {
   listen 1111;
   max_client_body_size 1k;
   location / {
+    allowed_method GET POST;
     alias ./docs/html/;
     index index.html;
   }

--- a/src/request/parse.cpp
+++ b/src/request/parse.cpp
@@ -38,6 +38,10 @@ void validate_method(const std::string& method) {
             throw status::bad_request;
         }
     }
+
+    if (method != "GET" && method != "POST" && method != "DELETE") {
+        throw status::not_implemented;
+    }
 }
 
 void validate_request_target(const std::string& request_target) {

--- a/src/response/HTTPResponse.cpp
+++ b/src/response/HTTPResponse.cpp
@@ -7,20 +7,25 @@ const std::string HTTPResponse::DEFAULT_VERSION = "HTTP/1.1";
 
 std::map<int, std::string> make_status_text() {
     std::map<int, std::string> status_text;
-    status_text[status::ok]                     = "OK";
-    status_text[status::moved_permanently]      = "Moved Permanently";
-    status_text[status::found]                  = "Found";
-    status_text[status::see_other]              = "See Other";
-    status_text[status::temporary_redirect]     = "Temporary Redirect";
-    status_text[status::permanent_redirect]     = "Permanent Redirect";
-    status_text[status::bad_request]            = "Bad Request";
-    status_text[status::forbidden]              = "Forbidden";
-    status_text[status::not_found]              = "Not Found";
-    status_text[status::method_not_allowed]     = "Method Not Allowed";
-    status_text[status::unsupported_media_type] = "Unsupported Methid Type";
-    status_text[status::server_error]           = "Internal Server Error";
-    status_text[status::bad_gateway]            = "Bad Gateway";
-    status_text[status::version_not_suppoted]   = "HTTP Version Not Supported";
+    status_text[status::ok]                       = "OK";
+    status_text[status::created]                  = "Created";
+    status_text[status::no_content]               = "No Content";
+    status_text[status::moved_permanently]        = "Moved Permanently";
+    status_text[status::found]                    = "Found";
+    status_text[status::see_other]                = "See Other";
+    status_text[status::temporary_redirect]       = "Temporary Redirect";
+    status_text[status::permanent_redirect]       = "Permanent Redirect";
+    status_text[status::bad_request]              = "Bad Request";
+    status_text[status::forbidden]                = "Forbidden";
+    status_text[status::not_found]                = "Not Found";
+    status_text[status::method_not_allowed]       = "Method Not Allowed";
+    status_text[status::request_entity_too_large] = "Request Entity Too Large";
+    status_text[status::uri_too_long]             = "Request URI Too Long";
+    status_text[status::unsupported_media_type]   = "Unsupported Methid Type";
+    status_text[status::server_error]             = "Internal Server Error";
+    status_text[status::not_implemented]          = "Not Implemented";
+    status_text[status::bad_gateway]              = "Bad Gateway";
+    status_text[status::version_not_suppoted] = "HTTP Version Not Supported";
     return status_text;
 }
 

--- a/src/response/HTTPStatus.hpp
+++ b/src/response/HTTPStatus.hpp
@@ -21,6 +21,7 @@ const code request_entity_too_large = 413;
 const code uri_too_long             = 414;
 const code unsupported_media_type   = 415;
 const code server_error             = 500;
+const code not_implemented          = 501;
 const code bad_gateway              = 502;
 const code version_not_suppoted     = 505;
 } // namespace status

--- a/src/response/setDafaultErrorBody.cpp
+++ b/src/response/setDafaultErrorBody.cpp
@@ -33,8 +33,9 @@ std::map<status::code, std::string> HTTPResponse::setDefaultErrorBody() {
     body[status::uri_too_long] = error_html("414 URI Too Long");
     body[status::unsupported_media_type] =
         error_html("415 Unsupported Media Type");
-    body[status::server_error] = error_html("500 Internal Server Error");
-    body[status::bad_gateway]  = error_html("502 Bad Gateway");
+    body[status::server_error]    = error_html("500 Internal Server Error");
+    body[status::not_implemented] = error_html("501 Not Implemented");
+    body[status::bad_gateway]     = error_html("502 Bad Gateway");
     body[status::version_not_suppoted] =
         error_html("505 HTTP Version Not Supported");
 

--- a/test/go_test/test_cases/error.go
+++ b/test/go_test/test_cases/error.go
@@ -34,12 +34,26 @@ func Error() {
 			expectStatus: http.StatusNotFound,
 		},
 		{
-			name: "MethodNotAllowed",
+			name: "MethodNotImplemented",
 			request: func() *http.Request {
 				port := ":1111"
 				target := ""
 				url := baseURL + port + target
 				req, err := http.NewRequest("HOGE", url, nil)
+				if err != nil {
+					panic(fmt.Errorf("NewRequest: %w", err))
+				}
+				return req
+			}(),
+			expectStatus: http.StatusNotImplemented,
+		},
+		{
+			name: "MethodNotAllowed",
+			request: func() *http.Request {
+				port := ":1111"
+				target := ""
+				url := baseURL + port + target
+				req, err := http.NewRequest("DELETE", url, nil)
 				if err != nil {
 					panic(fmt.Errorf("NewRequest: %w", err))
 				}


### PR DESCRIPTION
## やったこと

- status501とそのテスト実装

メソッドのバリデート時、GET, POST, DELETEのどれにも該当しなかった場合に`status::not_implemented`を投げるようにしました。

`src/request/parse.cpp`
```c++
    if (method != "GET" && method != "POST" && method != "DELETE") {
        throw status::not_implemented;
    }
```

## 動作確認

- go_test
```
❯ make go_test
go build
./webserv_tester
2022/07/08 12:26:00 RUN Get Test
2022/07/08 12:26:00  RUN: Index,NoTarget
2022/07/08 12:26:00  OK
2022/07/08 12:26:00  RUN: AutoIndexON,NoTarget
2022/07/08 12:26:00  OK
2022/07/08 12:26:00  RUN: NoIndex,NoTarget
2022/07/08 12:26:00  OK
2022/07/08 12:26:00 END Get Test
2022/07/08 12:26:00 RUN Post Test
2022/07/08 12:26:00  OK
2022/07/08 12:26:00 END Post Test
2022/07/08 12:26:00 RUN PostChunkedData Test
2022/07/08 12:26:00  OK
2022/07/08 12:26:00 END PostChunkedData Test
2022/07/08 12:26:00 RUN Error Test
2022/07/08 12:26:00  Run: NotFound
2022/07/08 12:26:00  OK
2022/07/08 12:26:00  Run: MethodNotImplemented
2022/07/08 12:26:00  OK
2022/07/08 12:26:00  Run: MethodNotAllowed
2022/07/08 12:26:00  OK
2022/07/08 12:26:00  Run: RequestEntityTooLarge
2022/07/08 12:26:00  OK
2022/07/08 12:26:00 END Error Test
2022/07/08 12:26:00 RUN BadRequest Test
2022/07/08 12:26:00  OK
2022/07/08 12:26:00 END BadRequest Test

```

- telnet
```
❯ telnet localhost 4242
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
HOGE / HTTP/1.1
HTTP/1.1 501 Not Implemented
Content-Length: 166
Content-Type: text/html; charset=utf-8

<html>
<head><title>501 Not Implemented</title></head>
<body>
<center><h1>501 Not Implemented</h1></center>
<hr><center>webserv/1.0.0</center>
</body>
</html>
Connection closed by foreign host.

```

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

## issues

about : #158 

close #158
