### PR TITLE
:recycle: Connection close をレスポンスに追加

### DIFF
--- a/src/event/method/Delete.cpp
+++ b/src/event/method/Delete.cpp
@@ -20,6 +20,7 @@ IOEvent* Delete::RegisterNext() {
     resp_.AppendHeader("Server", "Webserv/1.0.0");
     resp_.SetStatusCode(status::no_content);
     resp_.AppendHeader("Content-Length", "0");
+    resp_.AppendHeader("Connection", "close");
     resp_.PrintInfo();
     IOEvent* send_response = new SendResponse(stream_, resp_.ConvertToStr());
 

--- a/src/event/method/Get.cpp
+++ b/src/event/method/Get.cpp
@@ -121,6 +121,7 @@ void Get::processRedir(std::pair<int, std::string> redir) {
 
     HTTPResponse resp;
     resp.AppendHeader("Location", url);
+    resp.AppendHeader("Connection", "close");
     std::cout << "Location: " << url << std::endl;
     resp.SetStatusCode(redir.first);
     next_event_ = new SendResponse(stream_, resp.ConvertToStr());
@@ -170,6 +171,7 @@ void Get::prepareSendResponse(std::string content) {
     size << content.size();
     resp.AppendHeader("Content-Length", size.str());
     resp.AppendHeader("Content-Type", "text/html; charset=utf-8");
+    resp.AppendHeader("Connection", "close");
     resp.SetBody(content);
     resp.PrintInfo();
     next_event_ = new SendResponse(stream_, resp.ConvertToStr());
@@ -199,6 +201,7 @@ void Get::prepareEmptySendResponse() {
     HTTPResponse resp;
 
     resp.AppendHeader("Content-Length", "0");
+    resp.AppendHeader("Connection", "close");
     resp.PrintInfo();
     next_event_ = new SendResponse(stream_, resp.ConvertToStr());
 }

--- a/src/event/mode/ReadCGI.cpp
+++ b/src/event/mode/ReadCGI.cpp
@@ -55,13 +55,13 @@ IOEvent* ReadCGI::RegisterNext() {
         req_.SetMethod("GET");
         req_.SetRequestTarget(cgi_resp_.GetHeaderValue("location"));
         req_.SetBody("");
-        // req_.PrintInfo();
         new_event = RecvRequest::PrepareResponse(req_, stream_);
     } else {
         cgi_resp_.GenerateHTTPResponse(resp_);
 
         resp_.SetVersion(req_.GetVersion());
         resp_.AppendHeader("Server", "Webserv/1.0.0");
+        resp_.AppendHeader("connection", "close");
 
         new_event = new SendResponse(stream_, resp_.ConvertToStr());
         new_event->Register();

--- a/src/event/mode/ReadFile.cpp
+++ b/src/event/mode/ReadFile.cpp
@@ -60,6 +60,7 @@ IOEvent* ReadFile::RegisterNext() {
     resp_.AppendHeader("Content-Length", ss.str());
     resp_.SetBody(file_content_);
     resp_.AppendHeader("Server", "Webserv/1.0.0");
+    resp_.AppendHeader("Connection", "close");
     resp_.PrintInfo();
 
     IOEvent* send_response = new SendResponse(stream_, resp_.ConvertToStr());

--- a/src/event/mode/SendError.cpp
+++ b/src/event/mode/SendError.cpp
@@ -67,6 +67,7 @@ IOEvent* SendError::sendResponse() {
 
     resp.AppendHeader("Content-Length", body_size.str());
     resp.AppendHeader("Content-Type", "text/html; charset=utf-8");
+    resp.AppendHeader("Connection", "close");
     resp.PrintInfo();
 
     IOEvent* send_response = new SendResponse(stream_, resp.ConvertToStr());

--- a/src/event/mode/WriteFile.cpp
+++ b/src/event/mode/WriteFile.cpp
@@ -26,6 +26,7 @@ IOEvent* WriteFile::RegisterNext() {
     Unregister();
     resp_.AppendHeader("Content-Length", "0");
     resp_.AppendHeader("Server", "Webserv/1.0.0");
+    resp_.AppendHeader("Connection", "close");
     resp_.SetStatusCode(status::created);
     resp_.PrintInfo();
     IOEvent* send_response = new SendResponse(stream_, resp_.ConvertToStr());


### PR DESCRIPTION
## やったこと

- レスポンスに`Connection: close`を追加

## やらないこと

- `Connection: keep-alive`はやりません

## 動作確認

- それぞれのリスポンスをチェック

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

## issues

About: #165

close #165 
