### PR TITLE
:bug: getaddrinfoのエラー処理を最適化

### DIFF
--- a/src/event/mode/RecvRequest.cpp
+++ b/src/event/mode/RecvRequest.cpp
@@ -130,11 +130,16 @@ std::string RecvRequest::getAddrByHostName(std::string host_name) {
     hints.ai_flags    = AI_ADDRCONFIG | AI_NUMERICSERV;
     hints.ai_family   = PF_INET;
 
-    if (getaddrinfo(host_name.c_str(), NULL, &hints, &info) != 0)
-        throw status::server_error;
+    int res = getaddrinfo(host_name.c_str(), NULL, &hints, &info);
+    if (res != 0) {
+        if (res == EAI_NONAME)
+            std::cout << gai_strerror(res) << std::endl;
+        else
+            throw status::server_error;
+        return "";
+    }
     addr.s_addr = ((struct sockaddr_in*)(info->ai_addr))->sin_addr.s_addr;
     freeaddrinfo(info);
-
     return inet_ntoa(addr);
 }
 


### PR DESCRIPTION
## やったこと
- ```getaddrinfo```のエラー処理を最適化
  - ```getaddrinfo```の戻り値が```EAI_NONAME```：エラーメッセージ出力し、空文字返却
  - ```getaddrinfo```の戻り値がエラー系で```EAI_NONAME```以外：500エラー


## 動作確認
- 存在しないホスト名の際にエラーメッセージが出力され、空文字が返されることを確認
```
nodename nor servname provided, or not known <= エラーメッセージ
----- 以下デバッグ用出力 -----
config server name	:webserv
selected host name	:webserv
config addr		:127.0.0.1
selected addr		:              <=空文字返却

```
- 500エラーパターンは確認できてません。

## その他
トランジットの持ち時間で失礼します at ドバイ
