### PR TITLE
Fix/sigpipe

### DIFF
--- a/src/event/mode/RecvRequest.cpp
+++ b/src/event/mode/RecvRequest.cpp
@@ -41,6 +41,13 @@ void RecvRequest::Run(intptr_t offset) {
     if (recv_size == -1) {
         throw std::make_pair(stream_, status::server_error);
     }
+    if (recv_size == 0) {
+        return;
+    }
+
+#ifdef WS_DEBUG
+    std::cout << "recv_size: " << recv_size << std::endl;
+#endif
 
     try {
         HTTPParser::update_state(state_, std::string(buf, recv_size));

--- a/src/event/mode/SendResponse.cpp
+++ b/src/event/mode/SendResponse.cpp
@@ -1,6 +1,7 @@
 #include "SendResponse.hpp"
 
 #include <cerrno>
+#include <cstdio>
 #include <string>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -28,7 +29,7 @@ void SendResponse::Run(intptr_t offset) {
     ssize_t ret =
         send(stream_.GetSocketFd(), all_buf_.c_str(), all_buf_.size(), 0);
     if (ret < 0) {
-        throw SysError("send", errno);
+        perror("send");
     }
 }
 

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -12,6 +12,10 @@ void Server::Run() {
 }
 
 void Server::InitServer(std::string config_file_path) {
+    if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
+        perror("signal");
+        std::runtime_error("init error");
+    }
     ConfigParser::ParseConfigFile(config_file_path);
     executor_.Init();
     initListeners();


### PR DESCRIPTION
## やったこと

- クライアント側がコネクションを切断した際に、閉じたソケットに書き込みを行い、SIGPIPEシグナルが送られてサーバーが落ちてしまうことがあった。
-> SIGPIPEをハンドルするようにした。
- sendでエラーが発生した場合はperrorだけにしてサーバーは落とさないようにした。 
- firefoxからアクセスでサーバーが落ちる現象もこれに起因していたのかなという予想

- recv_sizeをデバッグログで出力

## 動作確認

- ブラウザで開き、sigpipeが送られてもサーバーが落ちないことを確認

## その他
cf. [世にも恐ろしいSIGPIPE、ソケットプログラミングの落とし穴](https://doi-t.hatenablog.com/entry/2014/06/10/033309)
## issues

about : #175 

see also : #152 

close #175 
close #152
