### PR TITLE
:bug: SendErrorのIOEventModeをSEND_RESPONSEに

### DIFF
--- a/src/event/mode/SendError.cpp
+++ b/src/event/mode/SendError.cpp
@@ -10,7 +10,7 @@
 #include <sstream>
 
 SendError::SendError(StreamSocket& stream, status::code code)
-    : stream_(stream), status_code_(code) {}
+    : IOEvent(SEND_RESPONSE), stream_(stream), status_code_(code) {}
 
 SendError::~SendError() {}
 

--- a/src/event/mode/SendResponse.cpp
+++ b/src/event/mode/SendResponse.cpp
@@ -40,7 +40,6 @@ void SendResponse::Unregister() {
 }
 
 IOEvent* SendResponse::RegisterNext() {
-    // TODO: keep-alive
     if (close(stream_.GetSocketFd()) == -1) {
         perror("close");
     }


### PR DESCRIPTION
## やったこと

- SendErrorのIOEventModeの初期化忘れでACCEPT_CONNになっていたので、EventExecutor内でdeleteされておらずleakしていたのを修正

## 動作確認

- 404エラーの後にleaksコマンドを打ってleakがないことを確認

## issues

about : #182 

close #182
